### PR TITLE
Fix bugs in unpack implementation

### DIFF
--- a/_workbench/misc/unpack.js
+++ b/_workbench/misc/unpack.js
@@ -79,7 +79,7 @@ function unpack(format, data) {
             label += format[formatPointer];
             formatPointer++;
         }
-        if (label === '/') {
+        if (format[formatPointer] === '/') {
             formatPointer++;
         }
 


### PR DESCRIPTION
Hey guys,

I found two bugs in unpack:

unpack('Nsize/Nerror', data) would fail because it didn't parse the '/' correctly, and any numeric modifiers such as unpack('N2size') would also fails because the algoritm was not bumping the data pointer by the correct number of bytes after unpacking each field.
