### PR TITLE
Fix base64 encode/decode functions to be consistent with PHP implementation

### DIFF
--- a/functions/url/base64_decode.js
+++ b/functions/url/base64_decode.js
@@ -9,7 +9,6 @@ function base64_decode (data) {
     // +   improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
     // +      input by: Brett Zamir (http://brett-zamir.me)
     // +   bugfixed by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
-    // -    depends on: utf8_decode
     // *     example 1: base64_decode('S2V2aW4gdmFuIFpvbm5ldmVsZA==');
     // *     returns 1: 'Kevin van Zonneveld'
     // mozilla has this native
@@ -51,7 +50,6 @@ function base64_decode (data) {
     } while (i < data.length);
 
     dec = tmp_arr.join('');
-    dec = this.utf8_decode(dec);
 
     return dec;
 }

--- a/functions/url/base64_encode.js
+++ b/functions/url/base64_encode.js
@@ -7,7 +7,6 @@ function base64_encode (data) {
     // +   bugfixed by: Pellentesque Malesuada
     // +   improved by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
     // +   improved by: Rafał Kukawski (http://kukawski.pl)
-    // -    depends on: utf8_encode
     // *     example 1: base64_encode('Kevin van Zonneveld');
     // *     returns 1: 'S2V2aW4gdmFuIFpvbm5ldmVsZA=='
     // mozilla has this native
@@ -24,8 +23,6 @@ function base64_encode (data) {
     if (!data) {
         return data;
     }
-
-    data = this.utf8_encode(data + '');
 
     do { // pack three octets into four hexets
         o1 = data.charCodeAt(i++);


### PR DESCRIPTION
The current base64_encode and base64_decode functions do not work properly with binary data because of the utf8 encoding/decoding built into the functions.
