### PR TITLE
http_build_query bugfixed

### DIFF
--- a/functions/url/http_build_query.js
+++ b/functions/url/http_build_query.js
@@ -8,6 +8,8 @@ function http_build_query (formdata, numeric_prefix, arg_separator) {
     // +    revised by: stag019
     // +   input by: Dreamer
     // +   bugfixed by: Brett Zamir (http://brett-zamir.me)
+    // +   bugfixed by: MIO_KODUKI (http://mio-koduki.blogspot.com/)
+    // %        note 1: If the value is null, key and value is skipped in http_build_query of PHP. But, phpjs is not.
     // -    depends on: urlencode
     // *     example 1: http_build_query({foo: 'bar', php: 'hypertext processor', baz: 'boom', cow: 'milk'}, '', '&amp;');
     // *     returns 1: 'foo=bar&amp;php=hypertext+processor&amp;baz=boom&amp;cow=milk'
@@ -23,17 +25,21 @@ function http_build_query (formdata, numeric_prefix, arg_separator) {
         } else if (val === false) {
             val = "0";
         }
-        if (val !== null && typeof(val) === "object") {
-            for (k in val) {
-                if (val[k] !== null) {
-                    tmp.push(_http_build_query_helper(key + "[" + k + "]", val[k], arg_separator));
+        if (val != null) {
+            if(typeof(val) === "object") {
+                for (k in val) {
+                    if (val[k] != null) {
+                        tmp.push(_http_build_query_helper(key + "[" + k + "]", val[k], arg_separator));
+                    }
                 }
+                return tmp.join(arg_separator);
+            } else if (typeof(val) !== "function") {
+                return that.urlencode(key) + "=" + that.urlencode(val);
+            } else {
+                throw new Error('There was an error processing for http_build_query().');
             }
-            return tmp.join(arg_separator);
-        } else if (typeof(val) !== "function") {
-            return that.urlencode(key) + "=" + that.urlencode(val);
         } else {
-            throw new Error('There was an error processing for http_build_query().');
+            return '';
         }
     };
 
@@ -45,7 +51,10 @@ function http_build_query (formdata, numeric_prefix, arg_separator) {
         if (numeric_prefix && !isNaN(key)) {
             key = String(numeric_prefix) + key;
         }
-        tmp.push(_http_build_query_helper(key, value, arg_separator));
+        var query=_http_build_query_helper(key, value, arg_separator);
+        if(query != '') {
+            tmp.push(query);
+        }
     }
 
     return tmp.join(arg_separator);


### PR DESCRIPTION
If the value is null, key and value is skipped in http_build_query of PHP. But, phpjs is not.
For example,
var g;
var data={"a":"b","c":"","d":0,"e":false,"f":null,"g":g};
"f" key and "g" key is skipped in http_build_query of PHP
So
a=b&c=&d=0&e=0
But phpjs
a=b&c=&d=0&e=0&f=null&g=undefined
