### PR TITLE
Fixed infinite loop in substr_count

### DIFF
--- a/functions/strings/substr_count.js
+++ b/functions/strings/substr_count.js
@@ -21,6 +21,9 @@ function substr_count (haystack, needle, offset, length) {
   if (isNaN(length)) {
     length = 0;
   }
+  if (needle.length == 0) {
+    return false;
+  }
   offset--;
 
   while ((offset = haystack.indexOf(needle, offset + 1)) != -1) {


### PR DESCRIPTION
If both needle and haystack are empty strings, enters an infinite loop.
PHP handles this as so:
php -r "var_dump(substr_count('', ''));"
PHP Warning:  substr_count(): Empty substring in Command line code on line 1
bool(false)
