### PR TITLE
Fix unpack to work with shorts

### DIFF
--- a/_workbench/misc/unpack.js
+++ b/_workbench/misc/unpack.js
@@ -166,7 +166,7 @@ function unpack(format, data) {
 
                 for (i=0;i<currentData.length;i+=2) {
                      // sum per word;
-                    currentResult = (currentData.charCodeAt(i+1) & 0xFF) << 8 +
+                    currentResult = ((currentData.charCodeAt(i+1) & 0xFF) << 8) +
                             (currentData.charCodeAt(i) & 0xFF);
                     if ((instruction === 's') && (currentResult >= 32768)) {
                         currentResult -= 65536;


### PR DESCRIPTION
Hi, I found a bug in function unpack(). In some cases this function returns wrong results, for example the following statement:
  unpack("ve_type/ve_machine", "\x02\x00\x3e\x00");

returns:
  ({e_type:0, e_machine:0})

while the expected result is:
  ({e_type:2, e_machine:62})

The bug comes from missing parenthesis around a binary shift operation.
