### PR TITLE
Infinite loop in strnatcasecmp

### DIFF
--- a/functions/strings/strnatcasecmp.js
+++ b/functions/strings/strnatcasecmp.js
@@ -114,6 +114,9 @@ function strnatcasecmp (str1, str2) {
     } else if (ca > cb) {
       return +1;
     }
+    
+    // prevent possible infinite loop
+    if (ia >= a.length && ib >= b.length) return 0;
 
     ++ia;
     ++ib;


### PR DESCRIPTION
Fixes bug where strnatcasecmp("churn rate", "churnrate") loops infinitely.
