### PR TITLE
money_format works incorrectly for fractions < 0.1

### DIFF
--- a/functions/strings/money_format.js
+++ b/functions/strings/money_format.js
@@ -121,6 +121,9 @@ function money_format (format, number) {
         dec_pt = '';
       } else if (right < fraction.length) {
         fraction = Math.round(parseFloat(fraction.slice(0, right) + '.' + fraction.substr(right, 1))) + '';
+        if (right > fraction.length) {
+          fraction = new Array(right - fraction.length + 1).join('0') + fraction; // prepend with 0's
+        }
       } else if (right > fraction.length) {
         fraction += new Array(right - fraction.length + 1).join('0'); // pad with 0's
       }


### PR DESCRIPTION
Hello,

money_format works incorrectly for fractions < 0.1

For instance, for frac_digits=2 the function returned:
money_format("%!i", 31.011); // 31.1
money_format("%!i", 31.01);  // 31.01
money_format("%!i", 31.009); // 31.1
