### PR TITLE
Alter function declaration to match others

### DIFF
--- a/functions/datetime/strtotime.js
+++ b/functions/datetime/strtotime.js
@@ -1,4 +1,4 @@
-strtotime: function(text, now) {
+function strtotime (text, now) {
 	// Convert string representation of date and time to a timestamp  
 	// 
 	// version: 1109.2015


### PR DESCRIPTION
All other function declarations are made by `function function_name (arg1, arg1)` this one was `function_name: function(arg1, arg2)` -- trying to standardize.

I'm working on a port of this collection for node.js and I am creating a script to restructure so it works for node.js.
