### PR TITLE
Update functions/url/http_build_query.js

### DIFF
--- a/functions/url/http_build_query.js
+++ b/functions/url/http_build_query.js
@@ -9,12 +9,15 @@ function http_build_query (formdata, numeric_prefix, arg_separator) {
   // +   input by: Dreamer
   // +   bugfixed by: Brett Zamir (http://brett-zamir.me)
   // +   bugfixed by: MIO_KODUKI (http://mio-koduki.blogspot.com/)
+  // +   improved by: Vadim Zozulya
   // %        note 1: If the value is null, key and value is skipped in http_build_query of PHP. But, phpjs is not.
   // -    depends on: urlencode
   // *     example 1: http_build_query({foo: 'bar', php: 'hypertext processor', baz: 'boom', cow: 'milk'}, '', '&amp;');
   // *     returns 1: 'foo=bar&amp;php=hypertext+processor&amp;baz=boom&amp;cow=milk'
   // *     example 2: http_build_query({'php': 'hypertext processor', 0: 'foo', 1: 'bar', 2: 'baz', 3: 'boom', 'cow': 'milk'}, 'myvar_');
   // *     returns 2: 'php=hypertext+processor&myvar_0=foo&myvar_1=bar&myvar_2=baz&myvar_3=boom&cow=milk'
+  // *     example 3: http_build_query({cat1: {key1: 'value1', key2: 'value2', key3: ['val1', 'val2']}, cat2: ['value1', 'value2'], cat3:'value'});
+  // *     returns 3: 'cat1[key1]=value1&cat1[key2]=value2&cat1[key3][]=val1&cat1[key3][]=val2&cat2[]=value1&cat2[]=value2&cat3=value'
   var value, key, tmp = [],
     that = this;
 
@@ -27,14 +30,22 @@ function http_build_query (formdata, numeric_prefix, arg_separator) {
     }
     if (val != null) {
       if(typeof(val) === "object") {
+        var start = 0;
         for (k in val) {
           if (val[k] != null) {
-            tmp.push(_http_build_query_helper(key + "[" + k + "]", val[k], arg_separator));
+            var sk, num = Number(k);
+            if(!isNaN(num) && num - start == 0) {
+              sk = '';
+              start++;
+            } else {
+              sk = that.urlencode(k);
+            }
+            tmp.push(_http_build_query_helper(key + "[" + sk + "]", val[k], arg_separator));
           }
         }
         return tmp.join(arg_separator);
       } else if (typeof(val) !== "function") {
-        return that.urlencode(key) + "=" + that.urlencode(val);
+        return key + "=" + that.urlencode(val);
       } else {
         throw new Error('There was an error processing for http_build_query().');
       }
@@ -51,7 +62,7 @@ function http_build_query (formdata, numeric_prefix, arg_separator) {
     if (numeric_prefix && !isNaN(key)) {
       key = String(numeric_prefix) + key;
     }
-    var query=_http_build_query_helper(key, value, arg_separator);
+    var query = _http_build_query_helper(that.urlencode(key), value, arg_separator);
     if(query != '') {
       tmp.push(query);
     }


### PR DESCRIPTION
1. Instead of ugly 'cat1%5Bkey1%5D=value1&cat1%5Bkey2%5D=value2' 
   my version will return more pretty and readable 'cat1[key1]=value1&cat1[key2]=value2'.
2. Simple arrays were generated as 'cat[0]=value1&cat[1]=value2' 
   and now they looks like 'cat[]=value1&cat[]=value2' (without redundant numeric indexes)
