### PR TITLE
[Fix] version compare with patch version

### DIFF
--- a/functions/info/version_compare.js
+++ b/functions/info/version_compare.js
@@ -38,8 +38,8 @@ function version_compare (v1, v2, operator) {
       'RC': -3,
       'rc': -3,
       '#': -2,
-      'p': -1,
-      'pl': -1
+      'p': 1,
+      'pl': 1
     },
     // This function will be called to prepare each version argument.
     // It replaces every _, -, and + with a dot.


### PR DESCRIPTION
Hi,

I am working porting version_compare from PHP to GO, and i was checking the code from PHPJS and i based my code on it, but i found a little bug running the full unit test from php-src.

https://github.com/php/php-src/blob/master/ext/standard/tests/versioning/version_compare.phpt

```
CompareVersion(    1.0 >= 1.0pl1) = true: want false
CompareVersion( 1.0pl1 le 1.0   ) = true: want false
CompareVersion(    1.0 <= 1.0pl1) = false: want true
CompareVersion(    1.0 < 1.0pl1) = false: want true
CompareVersion( 1.0pl1 gt 1.0   ) = false: want true
CompareVersion(    1.0 ge 1.0pl1) = true: want false
CompareVersion(    1.0 lt 1.0pl1) = false: want true
CompareVersion( 1.0pl1 lt 1.0   ) = true: want false
CompareVersion(    1.0 gt 1.0pl1) = true: want false
CompareVersion( 1.0pl1 ge 1.0   ) = false: want true
CompareVersion(    1.0 > 1.0pl1) = true: want false
CompareVersion(    1.0 le 1.0pl1) = false: want true
CompareVersion( 1.0pl1 <= 1.0   ) = true: want false
CompareVersion( 1.0pl1 >= 1.0   ) = false: want true
CompareVersion( 1.0pl1 > 1.0   ) = false: want true
CompareVersion( 1.0pl1 < 1.0   ) = true: want false
```

Just with my little fix version_compare have the same result in PHP and JS

Thanks and thanks!
