### PR TITLE
I found an issue in the bcmath component and tracked down the scale issue

### DIFF
--- a/functions/_phpjs_shared/_phpjs_shared_bc.js
+++ b/functions/_phpjs_shared/_phpjs_shared_bc.js
@@ -931,9 +931,9 @@ function _phpjs_shared_bc () {
             borrow = 1;
           } else {
             borrow = 0;
-            diff.n_value[diffptr--] = val;
-            //*diffptr-- = val;
           }
+          diff.n_value[diffptr--] = val;
+          //*diffptr-- = val;
         }
       }
 


### PR DESCRIPTION
See test case: bcadd("19.99","500",2), was producing -4.8, should have produced -480.01.

The fix is based on libbcmath code.
