### PR TITLE
Fix ie8 bug

### DIFF
--- a/functions/datetime/strtotime.js
+++ b/functions/datetime/strtotime.js
@@ -28,7 +28,7 @@ function strtotime (text, now) {
     }
 
     // Unecessary spaces
-    text = text.trim()
+    text = text.replace(/^\s+|\s+$/g, '')
         .replace(/\s{2,}/g, ' ')
         .replace(/[\t\r\n]/g, '')
         .toLowerCase();


### PR DESCRIPTION
String.trim() is not supported in ie8, replaced with String.replace(/^\s+|\s+$/g, '')
