### PR TITLE
Fix bug in tokenizer where buffer fails to find limit.

### DIFF
--- a/_workbench/tokenizer/token_get_all.js
+++ b/_workbench/tokenizer/token_get_all.js
@@ -365,7 +365,12 @@ function token_get_all (source) {
             }
             line += countNewLines(buffer);
             emitBuffer();
-            i = pos + limit.length - 1;
+            //If limit is not found, set i to the position of the end of the buffered characters
+            if(pos === -1){
+            	i = i + buffer.length;
+            }else{
+            	i = pos + limit.length - 1;
+            }
         },
         //This function is used to split a double quoted string or a heredoc buffer after a variable
         //has been found inside it


### PR DESCRIPTION
With regards to the `token_get_all()` function I noticed that if the php string being parsed ended with an in-line comment it would get trapped in an infinite loop.

Example:

```
token_get_all( "<?php //inline comment" );
```

The bug is in `getBufferAndEmit()` which is given starting text, and a limit and should buffer the parsed characters until that limit is reached. In the above case, the limit - `\n` - is never reached.

```
token_get_all( "<?php //inline comment" + "\n" );
```

on the other hand works fine. The reason is that the variable indicating our position in the parsed string is set to:

```
i = pos + limit.length - 1;
```

In the first example `pos` evaluates to `-1` and `limit.length` to 1. So we resetting ourselves to the beginning of the passed php code and so triggering an infinite loop.

The attached commit addresses this by dealing with the case where the limit is not found (`pos == 1`) separately. Specifically setting `i` to be the end of the buffered characters.
