### PR TITLE
Handle for values of 1e-7 and less

### DIFF
--- a/functions/strings/number_format.js
+++ b/functions/strings/number_format.js
@@ -56,7 +56,7 @@ function number_format(number, decimals, dec_point, thousands_sep) {
     s = '',
     toFixedFix = function(n, prec) {
       var k = Math.pow(10, prec);
-      return '' + Math.round(n * k) / k;
+      return '' + (Math.round(n * k) / k).toFixed(prec);
     };
   // Fix for IE parseFloat(0.55).toFixed(0) = 0;
   s = (prec ? toFixedFix(n, prec) : '' + Math.round(n))


### PR DESCRIPTION
When called with number_format(1e-8, 8, '.', ''). 
It returns '1e-8.00000000'.
Expected value '0.00000001'
