### PR TITLE
Update str_ireplace.js

### DIFF
--- a/functions/strings/str_ireplace.js
+++ b/functions/strings/str_ireplace.js
@@ -1,6 +1,5 @@
 function str_ireplace(search, replace, subject, count) {
   //  discuss at: http://phpjs.org/functions/str_ireplace/
-  // original by: Martijn Wieringa
   //  rewrite by: Glen Arason (http://CanadianDomainRegistry.ca)
   //            : Case-insensitive version of str_replace().
   //      format: str_ireplace(search, replace, subject[, count])


### PR DESCRIPTION
After submitting those bug fixes for str_replace() I thought I should have a look at str_ireplace().
I was surprised to learn that it doesn't take arrays as params, the optional count param, and particularly surprised to see it uses regex expressions with call backs.
Regex expressions are not required and create unnecessary processing.

Since str_replace is 100% compatible with its parent php variant I decided to see if it could be converted.
It turns out that with some pretty minor changes it is easily converted to its php version of str_ireplace().

This version of str_ireplace() is a complete rewrite and has all the code cleanliness and efficiencies of str_replace.

Have a look and see what you think.
Looking at it in the diff view doesn't do it justice with all the deletions highlighted.

I added additional comments so you could see where the modifications to str_replace() occurred.

Anyway, it's here for your consideration.
