### PR TITLE
Update str_replace.js

### DIFF
--- a/functions/strings/str_replace.js
+++ b/functions/strings/str_replace.js
@@ -25,8 +25,8 @@ function str_replace(search, replace, subject, count) {
   //   returns 3: 'AxDxAxDx'
   // bugfixed by: Glen Arason (http://CanadianDomainRegistry.ca) Corrected count
   //   example 4: str_replace(['A','D'], ['x','y'] , 'ASDFASDF' , 'cnt');
-  //   returns 4: 'xSyFxSyF' cnt = 0 (incorrect before fix)
-  //   returns 4: 'xSyFxSyF' cnt = 4 (correct after fix)
+  //   returns 4: 'xSyFxSyF' // cnt = 0 (incorrect before fix)
+  //   returns 4: 'xSyFxSyF' // cnt = 4 (correct after fix)
   
   var i = 0,
     j = 0,


### PR DESCRIPTION
The formula used to get the count value is incorrect.
The correct count is obtained by appending the matches found when calling split minus 1
(split.length -1).
