### PR TITLE
Fix travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
+  - "0.10"
   - "0.8"
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq php5-cli
+ - npm install -g npm@1.4
 script: make test


### PR DESCRIPTION
Hey.

Just noticed travis build started failing for this repo. And noticed it was because some of the dependencies started declaring dependencies with carets instead of tilde. So, just upgrading npm before the script starts fixes that.

Also, this adds node .10 into the test mix. It is after all the current stable version :)

Keep up the good work, and have a nice day!
