### PR TITLE
use performance.now() when available

### DIFF
--- a/functions/datetime/microtime.js
+++ b/functions/datetime/microtime.js
@@ -1,13 +1,26 @@
 function microtime(get_as_float) {
   //  discuss at: http://phpjs.org/functions/microtime/
   // original by: Paulo Freitas
+  // improved by Dumitru Uzun (http://duzun.me)
   //   example 1: timeStamp = microtime(true);
   //   example 1: timeStamp > 1000000000 && timeStamp < 2000000000
   //   returns 1: true
+  //   example 2: /^0\.[0-9]{1,6} [0-9]{10,10}$/.test(microtime())
+  //   returns 2: true
 
-  var now = new Date()
-    .getTime() / 1000;
-  var s = parseInt(now, 10);
 
-  return (get_as_float) ? now : (Math.round((now - s) * 1000) / 1000) + ' ' + s;
+    if ( typeof performance !== 'undefined' && performance.now ) {
+        var now = ( performance.now() + performance.timing.navigationStart ) / 1e3;
+        if(get_as_float) return now;
+
+        var s = now | 0; // Math.round(now)
+        return ( Math.round((now - s) * 1e6) / 1e6 ) + ' ' + s;
+    }
+    else {
+        var now = ( Date.now ? Date.now() : new Date().getTime() ) / 1e3;
+        if(get_as_float) return now;
+
+        var s = now | 0; // Math.round(now)
+        return ( Math.round((now - s) * 1e3) / 1e3 ) + ' ' + s;
+    }
 }


### PR DESCRIPTION
With performance.now() we can get more precision.
For ex. PHP version of microtime(true) has up to 6 digits after point. Using performance, the JS version returns the same precision.

I also replaced `var s = parseInt(now, 10);` with `var s = now | 0;`, because it is much faster,
and also `new Date().getTime()` with `Date.now()` for the same reason: [speed](https://duzun.me/playground/js_speed#c=d%20%3D%20Date.now%28%29%3B%20%2F%2F%20330%0A%2F%2Fd%20%3D%20new%20Date%28%29.getTime%28%29%3B%20%2F%2F%20625%0A%2F%2Fd%20%3D%20%2Bnew%20Date%3B%20%2F%2F%201048&d=console.log%28d%29%3B&i=var%20d%3B&n=1000000)
