### PR TITLE
warn that it's emulating php-on-linux

### DIFF
--- a/src/php/exec/escapeshellarg.js
+++ b/src/php/exec/escapeshellarg.js
@@ -1,5 +1,8 @@
 module.exports = function escapeshellarg (arg) {
   //  discuss at: https://locutus.io/php/escapeshellarg/
+  // Warning: this function emulates escapeshellarg() for php-running-on-linux
+  // the function behaves differently when running on Windows, which is not covered by this code.
+  // 
   // original by: Felix Geisendoerfer (https://www.debuggable.com/felix)
   // improved by: Brett Zamir (https://brett-zamir.me)
   //   example 1: escapeshellarg("kevin's birthday")


### PR DESCRIPTION
related to issue #395

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/locutusjs/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/locutusjs/locutus/pulls) for the same update/change?

### Description

the escape rules for windows is quite different, and PHP checks what OS it's compiled for and change the escapeshellarg() behaviour accordingly, but our escapeshellarg function does not check anything, it just always assumes it's running on ~~Windows~~ Linux. 

we should at the very least warn about it
(also i see 2 bugs in the function, but that's unrelated and should go in different PR's)