### PR TITLE
refuse to escape strings with null bytes

### DIFF
--- a/src/php/exec/escapeshellarg.js
+++ b/src/php/exec/escapeshellarg.js
@@ -4,6 +4,10 @@ module.exports = function escapeshellarg (arg) {
   // improved by: Brett Zamir (https://brett-zamir.me)
   //   example 1: escapeshellarg("kevin's birthday")
   //   returns 1: "'kevin\\'s birthday'"
+  
+  if(arg.indexOf("\x00") !== -1) {
+    throw new Error('escapeshellarg(): Argument #1 ($arg) must not contain any null bytes');
+  }
 
   var ret = ''
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/locutusjs/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/locutusjs/locutus/pulls) for the same update/change?

### Description

it's literally impossible to escape arguments with null bytes, and php also throws an error in this case, we should do the same.