### PR TITLE
fix bin2hex() unicode issue

### DIFF
--- a/src/php/strings/bin2hex.js
+++ b/src/php/strings/bin2hex.js
@@ -10,7 +10,7 @@ module.exports = function bin2hex (s) {
   //   example 2: bin2hex(String.fromCharCode(0x00))
   //   returns 2: '00'
   //   example 3: bin2hex("æ")
-  //   returns 3: c3a6
+  //   returns 3: 'c3a6'
 
   const arr = (new TextEncoder()).encode(s);
   let ret = "";

--- a/src/php/strings/bin2hex.js
+++ b/src/php/strings/bin2hex.js
@@ -4,23 +4,18 @@ module.exports = function bin2hex (s) {
   // bugfixed by: Onno Marsman (https://twitter.com/onnomarsman)
   // bugfixed by: Linuxworld
   // improved by: ntoniazzi (https://locutus.io/php/bin2hex:361#comment_177616)
+  // improved by: divinity76 ( https://github.com/divinity76 )
   //   example 1: bin2hex('Kev')
   //   returns 1: '4b6576'
   //   example 2: bin2hex(String.fromCharCode(0x00))
   //   returns 2: '00'
+  //   example 3: bin2hex("æ")
+  //   returns 3: c3a6
 
-  var i
-  var l
-  var o = ''
-  var n
-
-  s += ''
-
-  for (i = 0, l = s.length; i < l; i++) {
-    n = s.charCodeAt(i)
-      .toString(16)
-    o += n.length < 2 ? '0' + n : n
+  const arr = (new TextEncoder()).encode(s);
+  let ret = "";
+  for(let i = 0; i < arr.length; ++i){
+	  ret += arr[i].toString(16).padStart(2,"0");
   }
-
-  return o
+  return ret;
 }


### PR DESCRIPTION
fixes #427

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/locutusjs/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/locutusjs/locutus/pulls) for the same update/change?

### Description

the old implementation failed to encode unicode characters like æ ø å Æ Ø Å,
i managed to fix it with TextEncoder()