### PR TITLE
fix(php/str_replace): empty search strings should be ignored

### DIFF
--- a/src/php/strings/str_ireplace.js
+++ b/src/php/strings/str_ireplace.js
@@ -1,6 +1,7 @@
 module.exports = function str_ireplace (search, replace, subject, countObj) { // eslint-disable-line camelcase
   //  discuss at: https://locutus.io/php/str_ireplace/
   // original by: Glen Arason (https://CanadianDomainRegistry.ca)
+  // bugfixed by: Mahmoud Saeed
   //      note 1: Case-insensitive version of str_replace()
   //      note 1: Compliant with PHP 5.0 str_ireplace() Full details at:
   //      note 1: https://ca3.php.net/manual/en/function.str-ireplace.php
@@ -12,6 +13,8 @@ module.exports = function str_ireplace (search, replace, subject, countObj) { //
   //   example 2: str_ireplace('M', 'e', 'name', $countObj)
   //   example 2: var $result = $countObj.value
   //   returns 2: 1
+  //   example 3: str_ireplace('', '.', 'aaa')
+  //   returns 3: 'aaa'
 
   var i = 0
   var j = 0
@@ -76,6 +79,9 @@ module.exports = function str_ireplace (search, replace, subject, countObj) { //
       continue
     }
     for (j = 0, fl = f.length; j < fl; j++) {
+      if (f[j] === '') {
+        continue
+      }
       temp = s[i] + ''
       repl = ra ? (r[j] !== undefined ? r[j] : '') : r[0]
       s[i] = (temp).split(f[j]).join(repl)

--- a/src/php/strings/str_replace.js
+++ b/src/php/strings/str_replace.js
@@ -13,6 +13,7 @@ module.exports = function str_replace (search, replace, subject, countObj) { // 
   // bugfixed by: Oleg Eremeev
   // bugfixed by: Glen Arason (https://CanadianDomainRegistry.ca)
   // bugfixed by: Glen Arason (https://CanadianDomainRegistry.ca)
+  // bugfixed by: Mahmoud Saeed
   //    input by: Onno Marsman (https://twitter.com/onnomarsman)
   //    input by: Brett Zamir (https://brett-zamir.me)
   //    input by: Oleg Eremeev
@@ -28,6 +29,8 @@ module.exports = function str_replace (search, replace, subject, countObj) { // 
   //   example 4: str_replace(['A','D'], ['x','y'] , 'ASDFASDF' , countObj)
   //   example 4: var $result = countObj.value
   //   returns 4: 4
+  //   example 5: str_replace('', '.', 'aaa')
+  //   returns 5: 'aaa'
 
   var i = 0
   var j = 0
@@ -67,6 +70,9 @@ module.exports = function str_replace (search, replace, subject, countObj) { // 
       continue
     }
     for (j = 0, fl = f.length; j < fl; j++) {
+      if (f[j] === '') {
+        continue
+      }
       temp = s[i] + ''
       repl = ra ? (r[j] !== undefined ? r[j] : '') : r[0]
       s[i] = (temp).split(f[j]).join(repl)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/locutusjs/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/locutusjs/locutus/pulls) for the same update/change?

### Description
Unlike the native PHP function, `str_replace()` does not ignore empty search strings resulting in unexpected behavior.

For example:
```
// returns 'a.a.a'
// should return 'aaa'
str_replace('', '.', 'aaa');

// returns 'a.a.a'
// should return 'aaa'
str_replace([',', ''], '.', 'aaa')
```
