### PR TITLE
Fix extra arg consumption by %% (Fixes #441)

### DIFF
--- a/src/c/stdio/sprintf.js
+++ b/src/c/stdio/sprintf.js
@@ -35,7 +35,11 @@ module.exports = function sprintf (format, ...args) {
 
     // compiling with default clang params, mixed positional and non-positional params
     // give only a warning
-    const arg = param ? args[param - 1] : args[index++]
+    const arg = param ? args[param - 1] : args[index]
+
+    if (modifier !== '%') {
+      index++
+    }
 
     if (precision === undefined || isNaN(precision)) {
       precision = 'eEfFgG'.includes(modifier) ? 6 : (modifier === 's' ? String(arg).length : undefined)

--- a/src/c/stdio/sprintf.js
+++ b/src/c/stdio/sprintf.js
@@ -7,8 +7,11 @@ function pad (str, minLength, padChar, leftJustify) {
 
 module.exports = function sprintf (format, ...args) {
   // original by: Rafał Kukawski
+  // bugfixed by: Param Siddharth
   //   example 1: sprintf('%+10.*d', 5, 1)
   //   returns 1: '    +00001'
+  //   example 2: sprintf('%s is a %d%% %s %s.', 'Param', 90, 'good', 'boy')
+  //   returns 2: 'Param is a 90% good boy.'
   const placeholderRegex = /%(?:(\d+)\$)?([-+#0 ]*)(\*|\d+)?(?:\.(\*|\d*))?([\s\S])/g
 
   let index = 0


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/locutusjs/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/locutusjs/locutus/pulls) for the same update/change?

# Description
### Resolves #441: **\[`c/stdio/sprintf`\] %% consumes an extra arg**
When trying to use `%%` in `sprintf` to represent a `%` sign, it was consuming an extra value from `...args`.

## Modification
Conditionally incrementing `index` i. e. Only if `modifier` is not `%`.
``` js
  ...
  const arg = param ? args[param - 1] : args[index]

  if (modifier !== '%') {
    index++
  }

  if (precision === undefined || isNaN(precision)) {
  ...
``` 

The failure examples in #441 now work as desired:
- ``` js
  const str = sprintf('%d%%%d.', 1, 2);
  console.log(str);
  ```
  Output: `1%2.`
- ``` js
  const str = sprintf('%s is a %d%% %s %s.', 'Param', 90, 'good', 'boy');
  console.log(str);
  ```
  Output: `Param is a 90% good boy.`

