### PR TITLE
Prevent ReDos issue with regex inside gopher_parsedir

### DIFF
--- a/src/php/net-gopher/gopher_parsedir.js
+++ b/src/php/net-gopher/gopher_parsedir.js
@@ -22,7 +22,7 @@ module.exports = function gopher_parsedir (dirent) { // eslint-disable-line came
    * s = Audio file format, primarily a WAV file
    */
 
-  const entryPattern = /^(.)(.*?)\t(.*?)\t(.*?)\t(.*?)\u000d\u000a$/
+  const entryPattern = /^(.)([^\t]*)\t([^\t]*)\t([^\t]*)\t([^\t]*)\r\n$/
   const entry = dirent.match(entryPattern)
 
   if (entry === null) {


### PR DESCRIPTION
Passing specific string  to gopher_parsedir may result in long excesively long evaluation by the regex used inside the function.
This patch should prevent it.