### PR TITLE
Check if perfomance has timing property

### DIFF
--- a/src/php/datetime/microtime.js
+++ b/src/php/datetime/microtime.js
@@ -10,7 +10,11 @@ module.exports = function microtime (getAsFloat) {
 
   let s
   let now
-  if (typeof performance !== 'undefined' && performance.now) {
+  if (
+    typeof performance !== 'undefined' &&
+    performance.now &&
+    performance.timing
+  ) {
     now = (performance.now() + performance.timing.navigationStart) / 1e3
     if (getAsFloat) {
       return now


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/locutusjs/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/locutusjs/locutus/pulls) for the same update/change?

### Description

https://github.com/nodejs/node/issues/28635

performance became a global variable on node 16, but it does not have timing property.
and it's throwing following error.

I think this fix does not worth comments so I omitted examples and credit.

```
> m = require('./microtime')
[Function: microtime]
> m()
Uncaught TypeError: Cannot read properties of undefined (reading 'navigationStart')
    at microtime (.../locutus/src/php/datetime/microtime.js:17:51)
```