### PR TITLE
Fix strftime implementations for format strings "%F" and "%j"

### DIFF
--- a/src/php/datetime/strftime.js
+++ b/src/php/datetime/strftime.js
@@ -8,6 +8,9 @@ module.exports = function strftime(fmt, timestamp) {
   //           note 1: Uses global: locutus to store locale info
   //        example 1: strftime("%A", 1062462400); // Return value will depend on date and locale
   //        returns 1: 'Tuesday'
+  //      bugfixed by: Markus Marchewa
+  //        example 2: strftime('%F', 1577836800);
+  //        returns 2: '2020-01-01'
 
   const setlocale = require('../strings/setlocale')
 
@@ -160,7 +163,7 @@ module.exports = function strftime(fmt, timestamp) {
   const _aggregates = {
     c: 'locale',
     D: '%m/%d/%y',
-    F: '%y-%m-%d',
+    F: '%Y-%m-%d',
     h: '%b',
     n: '\n',
     r: 'locale',

--- a/test/generated/php/datetime/test-strftime.js
+++ b/test/generated/php/datetime/test-strftime.js
@@ -22,4 +22,10 @@ describe('src/php/datetime/strftime.js (tested in test/generated/php/datetime/te
     expect(result).to.deep.equal(expected)
     done()
   })
+  it('should pass example 3', function (done) {
+    var expected = '091'
+    var result = (() => {let e = process.env, tz = e.TZ; e.TZ = 'Europe/Vienna'; let r = strftime('%j', 1680307200); e.TZ = tz; return r;})();
+    expect(result).to.deep.equal(expected)
+    done()
+  })
 })

--- a/test/generated/php/datetime/test-strftime.js
+++ b/test/generated/php/datetime/test-strftime.js
@@ -16,4 +16,10 @@ describe('src/php/datetime/strftime.js (tested in test/generated/php/datetime/te
     expect(result).to.deep.equal(expected)
     done()
   })
+  it('should pass example 2', function (done) {
+    var expected = '2020-01-01'
+    var result = strftime('%F', 1577836800);
+    expect(result).to.deep.equal(expected)
+    done()
+  })
 })


### PR DESCRIPTION
## Description

1.) "%F" is supposed to be same as "%Y-%m-%d" (https://www.php.net/manual/en/function.strftime.php) but was "%y-…"

2.) "%j" (day of the year) was wrong in locales with DST shifts because the interval between the start of a day during DST and the start of the year might be less than a multiple of 24 hours (the day when DST starts has just 23 hours and the day when it ends has 25 hours). Compensate by talking the timezone offsets into calculation. The test changes `process.env.TZ` temporarily.

## Checklist

Yes,

- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/locutusjs/locutus/pulls) for
      the same update/change?
- [X] I have followed the guidelines in our
      [Contributing](https://github.com/locutusjs/locutus/blob/main/CONTRIBUTING.md) and e.g. bundled a test in the
      function header comments that fails before this PR, but passes after.
