### PR TITLE
feat: Add silent flag to unserialize console error

### DIFF
--- a/src/php/var/unserialize.js
+++ b/src/php/var/unserialize.js
@@ -390,12 +390,12 @@ module.exports = function unserialize(str, errorMode = 'log') {
 
     return expectType(str, initCache())[0]
   } catch (err) {
-	if (errorMode === 'throw') {
-		throw err;
-	} else if (errorMode === 'log') {
-		console.error(err);
-	}
-	// if silent mode we do nothing
+    if (errorMode === 'throw') {
+      throw err
+    } else if (errorMode === 'log') {
+      console.error(err)
+    }
+    // if silent mode we do nothing
     return false
   }
 }


### PR DESCRIPTION
## Description

Allow skipping error logging when unnecessary, while still providing the ability to rethrow the error

## Checklist

Yes,

- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/locutusjs/locutus/pulls) for
      the same update/change?
- [x] I have followed the guidelines in our
      [Contributing](https://github.com/locutusjs/locutus/blob/main/CONTRIBUTING.md) and e.g. bundled a test in the
      function header comments that fails before this PR, but passes after.
