### PR TITLE
test: enable array_search tests, update backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ the hundreds of contributions across the many languages that Locutus is assimila
 
 Ideas that will be planned and find their way into a release at one point
 
-- [ ] Address the 25 remaining test failures that are currently skipped (find out which ones via
-      `yarn test:languages:noskip`)
+- [x] ~~Address the 25 remaining test failures~~ → reduced to 1 (`set_time_limit` is intentionally untestable)
 - [ ] Compare example test cases for PHP against `php -r` to make sure they are correctly mimicking the most recent
       stable behavior
 - [ ] Have _one_ way of checking pure JS arrays vs PHP arrays (vs:

--- a/src/php/array/array_search.js
+++ b/src/php/array/array_search.js
@@ -4,7 +4,6 @@ module.exports = function array_search(needle, haystack, argStrict) {
   //    input by: Brett Zamir (https://brett-zamir.me)
   // bugfixed by: Kevin van Zonneveld (https://kvz.io)
   // bugfixed by: Reynier de la Rosa (https://scriptinside.blogspot.com.es/)
-  //        test: skip-all
   //   example 1: array_search('zonneveld', {firstname: 'kevin', middle: 'van', surname: 'zonneveld'})
   //   returns 1: 'surname'
   //   example 2: array_search('3', {a: 3, b: 5, c: 7})

--- a/test/generated/php/array/test-array_search.js
+++ b/test/generated/php/array/test-array_search.js
@@ -9,7 +9,7 @@ var ini_set = require('../../../../src/php/info/ini_set')
 var ini_get = require('../../../../src/php/info/ini_get')
 var array_search = require('../../../../src/php/array/array_search.js')
 
-describe.skip('src/php/array/array_search.js (tested in test/generated/php/array/test-array_search.js)', function () {
+describe('src/php/array/array_search.js (tested in test/generated/php/array/test-array_search.js)', function () {
   it('should pass example 1', function (done) {
     var expected = 'surname'
     var result = array_search('zonneveld', {firstname: 'kevin', middle: 'van', surname: 'zonneveld'})


### PR DESCRIPTION
## Summary

- Remove `skip-all` from `array_search.js` - tests pass
- Update CHANGELOG backlog: ~~25 skipped~~ → 1 remaining (`set_time_limit` is intentionally untestable)

## Test Results

- 925 passing, 1 pending (was 923 passing, 3 pending before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)