### PR TITLE
Fix: wrap object literals in parentheses for evaluation

### DIFF
--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -315,7 +315,13 @@ function createBaseContext(extra: Record<string, unknown> = {}): vm.Context {
 function evaluateExpected(expectedRaw: string): { success: boolean; result: string; error?: string } {
   try {
     const context = createBaseContext()
-    const value = vm.runInContext(expectedRaw, context)
+    // Wrap object literals in parentheses to make them expressions, not blocks
+    // e.g., {key: value} -> ({key: value})
+    let code = expectedRaw.trim()
+    if (code.startsWith('{') && !code.startsWith('{"')) {
+      code = `(${code})`
+    }
+    const value = vm.runInContext(code, context)
     return { success: true, result: normalizeJsResult(value) }
   } catch (e) {
     return { success: false, result: '', error: String(e) }


### PR DESCRIPTION
## Summary

Object literals like `{key: value}` were being interpreted as block statements when evaluated. Wrapping them in parentheses makes them proper expressions.

## Test plan

- [x] `yarn check` passes
- [x] `php/strings/count_chars` now passes (was failing with "Expected eval error")
- [x] Verification improved: 44/91 passing (was 43/91)

🤖 Generated with [Claude Code](https://claude.com/claude-code)