### PR TITLE
fix(node25): fix async queue drain and indentString compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,35 +1,24 @@
 {
-    "name": "locutusjs/locutus",
-    "description": "Locutus other languages' standard libraries to JavaScript for fun and educational purposes",
-    "type": "library",
-    "keywords": [
-        "php",
-        "golang",
-        "c",
-        "ruby",
-        "python",
-        "js",
-        "locutus",
-        "javascript",
-        "polyfill",
-        "standard-library"
-    ],
-    "homepage": "https://locutus.io",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Kevin van Zonneveld",
-            "email": "kevin@vanzonneveld.net"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/locutusjs/locutus/issues",
-        "source": "https://github.com/locutusjs/locutus"
-    },
-    "require": {
-        "php": ">=8.0"
-    },
-    "config": {
-        "sort-packages": true
+  "name": "locutusjs/locutus",
+  "description": "Locutus other languages' standard libraries to JavaScript for fun and educational purposes",
+  "type": "library",
+  "keywords": ["php", "golang", "c", "ruby", "python", "js", "locutus", "javascript", "polyfill", "standard-library"],
+  "homepage": "https://locutus.io",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Kevin van Zonneveld",
+      "email": "kevin@vanzonneveld.net"
     }
+  ],
+  "support": {
+    "issues": "https://github.com/locutusjs/locutus/issues",
+    "source": "https://github.com/locutusjs/locutus"
+  },
+  "require": {
+    "php": ">=8.0"
+  },
+  "config": {
+    "sort-packages": true
+  }
 }

--- a/src/_util/util.js
+++ b/src/_util/util.js
@@ -5,7 +5,8 @@ const fsPromises = fs.promises
 const async = require('async')
 const YAML = require('js-yaml')
 const debug = require('debug')('locutus:utils')
-const indentString = require('indent-string')
+const indentStringModule = require('indent-string')
+const indentString = indentStringModule.default || indentStringModule
 const _ = require('lodash')
 const esprima = require('esprima')
 
@@ -181,7 +182,7 @@ class Util {
 
     q.push(files)
 
-    q.drain = cb
+    q.drain(cb)
   }
 
   _reindexOne(params, cb) {


### PR DESCRIPTION
## Summary

- Fix async queue drain property assignment failing on Node 25
- Handle ESM default export for indent-string in case of version mismatch

### Changes

- `q.drain = cb` → `q.drain(cb)` - the property assignment form fails in Node v25 with async 2.6.4
- Added fallback for indent-string ESM default export handling

### Test plan

- [x] All 925 tests pass on Node v25.2.1
- [x] Biome lint passes (13 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)