### PR TITLE
fix: pull Docker images once at init, not per-function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ website/vendor/cache/
 .history
 .cache/
 .claude/ralph-loop.local.md
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Fixes repeated "Pulling php:8.3-cli..." messages during parity tests
- Tracks pulled images in a Set so subsequent calls skip redundant pulls
- Adds `.playwright-mcp/` to .gitignore

## Before
```
Pulling php:8.3-cli...
Pulling php:8.3-cli...
Pulling php:8.3-cli...
(repeated 50+ times for each function tested in parallel)
```

## After
```
Pulling php:8.3-cli...
  Digest: php@sha256:...
Pulling python:3.12...
  Digest: python@sha256:...
```

## Test plan
- [x] `yarn test:parity` shows each image pulled only once
- [x] All 179 parity tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)