### PR TITLE
fix: Add atof to C parity verification (12/18 functions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ working 2026-01-07, Insight search)
       - [x] Go: 20 functions verified against Go 1.23
       - [x] Python: 15/17 (88%) - remaining: capwords (impl difference), printable (.length)
       - [x] Ruby: 16/18 (89%) - remaining: sample (random), acos (example incompatible)
-      - [x] C: 11/18 (61%) - remaining: sprintf, strchr, strstr, strcat, frexp, isspace, atof (complex/different semantics)
+      - [x] C: 12/18 (67%) - remaining: sprintf, strchr, strstr, strcat, frexp, isspace (complex/different semantics)
       - [x] Infrastructure: parallel execution, caching, modular architecture, per-language handlers, type-safe config
       - [x] CI integration: `parity verified:` header in function files, Zod validation, `yarn test:parity`
       - [x] Badge: "Verified against PHP 8.3" (added to README, PR #501)

--- a/src/c/stdlib/atof.js
+++ b/src/c/stdlib/atof.js
@@ -1,13 +1,14 @@
 module.exports = function atof(str) {
-  //  discuss at: https://locutus.io/c/stdlib/atof/
-  // original by: Kevin van Zonneveld (https://kvz.io)
-  //      note 1: Converts a string to a floating-point number.
-  //   example 1: atof('3.14')
-  //   returns 1: 3.14
-  //   example 2: atof('  -2.5e10')
-  //   returns 2: -25000000000
-  //   example 3: atof('abc')
-  //   returns 3: 0
+  //      discuss at: https://locutus.io/c/stdlib/atof/
+  // parity verified: C 23
+  //     original by: Kevin van Zonneveld (https://kvz.io)
+  //          note 1: Converts a string to a floating-point number.
+  //       example 1: atof('3.14')
+  //       returns 1: 3.14
+  //       example 2: atof('  -2.5e10')
+  //       returns 2: -25000000000
+  //       example 3: atof('abc')
+  //       returns 3: 0
 
   str = (str + '').replace(/^\s+/, '')
   const result = parseFloat(str)

--- a/test/parity/lib/languages/c.ts
+++ b/test/parity/lib/languages/c.ts
@@ -56,8 +56,6 @@ export const C_SKIP_LIST = new Set<string>([
   'frexp',
   // JS isspace handles strings, C only handles single char
   'isspace',
-  // atof output format differs (scientific notation vs decimal)
-  'atof',
 ])
 
 /**


### PR DESCRIPTION
## Summary
- `atof` actually passes parity tests, was incorrectly skipped
- C verification now at 67% (12/18 functions)

## Test plan
- [x] `yarn test:parity --filter c/` passes (12 verified)
- [x] `yarn check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)