### PR TITLE
docs: Fix CHANGELOG typos and add iteration 31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Ideas that will be planned and find their way into a release at one point
       `Function/'function'/'Class::function'/[$object, 'function']`, and use that in `is_callable`, `array_walk`,
       `call_user_func_array` etc.
 - [ ] Parse `require`s with ts-morph and add them to the function params and types. Then we can add show internal dependencies on website, with links to them
-working 2026-01-07, Insight search)
 - [ ] Verification: verify examples against native runtimes with Docker (balance efforts across languages)
       - [x] PHP: 164 functions verified against PHP 8.3
       - [x] Go: 20 functions verified against Go 1.23
@@ -49,8 +48,8 @@ working 2026-01-07, Insight search)
 - [ ] Docs/Website:
       - [x] The function pages could have a badge themselves in which language version they were parity checked (similar to what was added in the README.md)
       - [x] website: Render authors server-side (PR #511)
-      - [x] website: Fix the search functionality (verified       
-      - [ ] Hexo → Next.js 16 SSG(?) Or just a Hexo upgrade. Maybe it's fine.
+      - [x] website: Fix the search functionality (verified working 2026-01-07)
+      - [x] Hexo upgrade to 8.1.1 (PR #512) - Next.js migration deferred
       - [x] Fix Search by function name or behavior (verified working 2026-01-07)
       - [ ] "Rosetta Stone" view for cross-language comparison
 

--- a/docs/prompts/LOG.md
+++ b/docs/prompts/LOG.md
@@ -403,3 +403,24 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
   - Infrastructure: 2 (25, 26)
   - Modernization: 1 (23)
 - Should summarize iterations 21-30 per LOG.md rules
+
+### Iteration 31
+
+2026-01-08
+
+- **Area: Website (Modernization)**
+- Upgraded Hexo 7.1.1 → 8.1.1 (PR #512):
+  - Upgraded hexo from 7.1.1 to 8.1.1
+  - Upgraded hexo-cli from 4.3.1 to 4.3.2
+  - Upgraded hexo-renderer-marked from 6.3.0 to 7.0.1
+  - Fixed breaking change: `external_link` config from boolean to object format
+  - Removed unused ESLint devDependencies (project uses Biome)
+  - Updated Node engine requirement from >= 10 to >= 22
+  - Updated packageManager to yarn 4.12.0
+- Tested with Playwright MCP:
+  - Home page renders correctly
+  - PHP function list page works
+  - Individual function pages display "✓ Verified: PHP 8.3" badges
+- All 927 tests pass
+- Fixed CHANGELOG.md typos (stray text, incomplete line)
+- Addresses backlog item "Hexo → Next.js or upgrade" (partial - upgrade done)


### PR DESCRIPTION
## Summary
- Remove stray text on line 26 ("working 2026-01-07, Insight search)")
- Fix incomplete search functionality line (missing close parenthesis)
- Mark Hexo upgrade as complete (PR #512)
- Add iteration 31 to LOG.md documenting Hexo 8 upgrade

## Test plan
- [x] No code changes - documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)