### PR TITLE
feat(ruby): Add Math.sqrt, Math.sin, Math.cos functions

### DIFF
--- a/src/ruby/Math/cos.js
+++ b/src/ruby/Math/cos.js
@@ -1,0 +1,12 @@
+module.exports = function cos(x) {
+  //      discuss at: https://locutus.io/ruby/Math/cos/
+  // parity verified: Ruby 3.3
+  //     original by: Kevin van Zonneveld (https://kvz.io)
+  //          note 1: Precision may vary across platforms
+  //       example 1: cos(0)
+  //       returns 1: 1
+  //       example 2: cos(1)
+  //       returns 2: 0.5403023058681398
+
+  return Math.cos(x)
+}

--- a/src/ruby/Math/sin.js
+++ b/src/ruby/Math/sin.js
@@ -1,0 +1,12 @@
+module.exports = function sin(x) {
+  //      discuss at: https://locutus.io/ruby/Math/sin/
+  // parity verified: Ruby 3.3
+  //     original by: Kevin van Zonneveld (https://kvz.io)
+  //          note 1: Precision may vary across platforms
+  //       example 1: sin(0)
+  //       returns 1: 0
+  //       example 2: sin(1)
+  //       returns 2: 0.8414709848078965
+
+  return Math.sin(x)
+}

--- a/src/ruby/Math/sqrt.js
+++ b/src/ruby/Math/sqrt.js
@@ -1,0 +1,13 @@
+module.exports = function sqrt(x) {
+  //      discuss at: https://locutus.io/ruby/Math/sqrt/
+  // parity verified: Ruby 3.3
+  //     original by: Kevin van Zonneveld (https://kvz.io)
+  //       example 1: sqrt(4)
+  //       returns 1: 2
+  //       example 2: sqrt(9)
+  //       returns 2: 3
+  //       example 3: sqrt(2)
+  //       returns 3: 1.4142135623730951
+
+  return Math.sqrt(x)
+}


### PR DESCRIPTION
## Summary
- Adds Ruby Math.sqrt, Math.sin, Math.cos functions with parity verification
- Refactors Ruby parity handler to infer category from directory path (like Python handler)
- New Math functions now work automatically without needing to add them to RUBY_METHODS mapping

## Test plan
- [x] All 940 tests pass (`yarn check`)
- [x] Ruby parity tests pass for sqrt, sin, cos (`yarn test:parity ruby --all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)