### PR TITLE
feat(ruby): Add Math.exp, Math.log, Math.tan functions

### DIFF
--- a/src/ruby/Math/exp.js
+++ b/src/ruby/Math/exp.js
@@ -1,0 +1,11 @@
+module.exports = function exp(x) {
+  //      discuss at: https://locutus.io/ruby/Math/exp/
+  // parity verified: Ruby 3.3
+  //     original by: Kevin van Zonneveld (https://kvz.io)
+  //       example 1: exp(0)
+  //       returns 1: 1
+  //       example 2: exp(1)
+  //       returns 2: 2.718281828459045
+
+  return Math.exp(x)
+}

--- a/src/ruby/Math/log.js
+++ b/src/ruby/Math/log.js
@@ -1,0 +1,11 @@
+module.exports = function log(x) {
+  //      discuss at: https://locutus.io/ruby/Math/log/
+  // parity verified: Ruby 3.3
+  //     original by: Kevin van Zonneveld (https://kvz.io)
+  //       example 1: log(1)
+  //       returns 1: 0
+  //       example 2: log(2.718281828459045)
+  //       returns 2: 1
+
+  return Math.log(x)
+}

--- a/src/ruby/Math/tan.js
+++ b/src/ruby/Math/tan.js
@@ -1,0 +1,11 @@
+module.exports = function tan(x) {
+  //      discuss at: https://locutus.io/ruby/Math/tan/
+  // parity verified: Ruby 3.3
+  //     original by: Kevin van Zonneveld (https://kvz.io)
+  //       example 1: tan(0)
+  //       returns 1: 0
+  //       example 2: tan(1)
+  //       returns 2: 1.5574077246549023
+
+  return Math.tan(x)
+}


### PR DESCRIPTION
## Summary
- Adds Ruby Math.exp, Math.log, Math.tan functions with parity verification
- All 22 Ruby parity tests pass (up from 19)

## Test plan
- [x] All 946 tests pass (`yarn check`)
- [x] Ruby parity tests pass (`yarn test:parity ruby --all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)