### PR TITLE
refactor(php): Use Array.isArray() instead of Object.prototype.toString

### DIFF
--- a/src/php/array/array_change_key_case.js
+++ b/src/php/array/array_change_key_case.js
@@ -20,7 +20,7 @@ module.exports = function array_change_key_case(array, cs) {
   let key
   const tmpArr = {}
 
-  if (Object.prototype.toString.call(array) === '[object Array]') {
+  if (Array.isArray(array)) {
     return array
   }
 

--- a/src/php/array/array_chunk.js
+++ b/src/php/array/array_chunk.js
@@ -24,7 +24,7 @@ module.exports = function array_chunk(input, size, preserveKeys) {
     return null
   }
 
-  if (Object.prototype.toString.call(input) === '[object Array]') {
+  if (Array.isArray(input)) {
     if (preserveKeys) {
       while (i < l) {
         ;(x = i % size) ? (n[c][i] = input[i]) : (n[++c] = {})

--- a/src/php/array/array_diff_uassoc.js
+++ b/src/php/array/array_diff_uassoc.js
@@ -16,12 +16,7 @@ module.exports = function array_diff_uassoc(arr1) {
 
   const $global = typeof window !== 'undefined' ? window : global
 
-  cb =
-    typeof cb === 'string'
-      ? $global[cb]
-      : Object.prototype.toString.call(cb) === '[object Array]'
-        ? $global[cb[0]][cb[1]]
-        : cb
+  cb = typeof cb === 'string' ? $global[cb] : Array.isArray(cb) ? $global[cb[0]][cb[1]] : cb
 
   arr1keys: for (k1 in arr1) {
     for (i = 1; i < arglm1; i++) {

--- a/src/php/array/array_diff_ukey.js
+++ b/src/php/array/array_diff_ukey.js
@@ -17,12 +17,7 @@ module.exports = function array_diff_ukey(arr1) {
 
   const $global = typeof window !== 'undefined' ? window : global
 
-  cb =
-    typeof cb === 'string'
-      ? $global[cb]
-      : Object.prototype.toString.call(cb) === '[object Array]'
-        ? $global[cb[0]][cb[1]]
-        : cb
+  cb = typeof cb === 'string' ? $global[cb] : Array.isArray(cb) ? $global[cb[0]][cb[1]] : cb
 
   arr1keys: for (k1 in arr1) {
     for (i = 1; i < arglm1; i++) {

--- a/src/php/array/array_filter.js
+++ b/src/php/array/array_filter.js
@@ -23,7 +23,7 @@ module.exports = function array_filter(arr, func) {
     }
 
   // @todo: Issue #73
-  if (Object.prototype.toString.call(arr) === '[object Array]') {
+  if (Array.isArray(arr)) {
     retObj = []
   }
 

--- a/src/php/array/array_intersect_uassoc.js
+++ b/src/php/array/array_intersect_uassoc.js
@@ -18,16 +18,11 @@ module.exports = function array_intersect_uassoc(arr1) {
 
   const $global = typeof window !== 'undefined' ? window : global
 
-  cb =
-    typeof cb === 'string'
-      ? $global[cb]
-      : Object.prototype.toString.call(cb) === '[object Array]'
-        ? $global[cb[0]][cb[1]]
-        : cb
+  cb = typeof cb === 'string' ? $global[cb] : Array.isArray(cb) ? $global[cb[0]][cb[1]] : cb
 
   // cb0 = (typeof cb0 === 'string')
   //   ? $global[cb0]
-  //   : (Object.prototype.toString.call(cb0) === '[object Array]')
+  //   : (Array.isArray(cb0))
   //     ? $global[cb0[0]][cb0[1]]
   //     : cb0
 

--- a/src/php/array/array_intersect_ukey.js
+++ b/src/php/array/array_intersect_ukey.js
@@ -18,16 +18,11 @@ module.exports = function array_intersect_ukey(arr1) {
 
   const $global = typeof window !== 'undefined' ? window : global
 
-  cb =
-    typeof cb === 'string'
-      ? $global[cb]
-      : Object.prototype.toString.call(cb) === '[object Array]'
-        ? $global[cb[0]][cb[1]]
-        : cb
+  cb = typeof cb === 'string' ? $global[cb] : Array.isArray(cb) ? $global[cb[0]][cb[1]] : cb
 
   // cb0 = (typeof cb0 === 'string')
   //   ? $global[cb0]
-  //   : (Object.prototype.toString.call(cb0) === '[object Array]')
+  //   : (Array.isArray(cb0))
   //     ? $global[cb0[0]][cb0[1]]
   //     : cb0
 

--- a/src/php/array/array_multisort.js
+++ b/src/php/array/array_multisort.js
@@ -91,7 +91,7 @@ module.exports = function array_multisort(arr) {
   // Store first argument into sortArrs and sortKeys if an Object.
   // First Argument should be either a Javascript Array or an Object,
   // otherwise function would return FALSE like in PHP
-  if (Object.prototype.toString.call(arr) === '[object Array]') {
+  if (Array.isArray(arr)) {
     sortArrs[0] = arr
   } else if (arr && typeof arr === 'object') {
     for (i in arr) {
@@ -115,7 +115,7 @@ module.exports = function array_multisort(arr) {
   // of arrays and adding them to the above variables.
   const argl = arguments.length
   for (j = 1; j < argl; j++) {
-    if (Object.prototype.toString.call(arguments[j]) === '[object Array]') {
+    if (Array.isArray(arguments[j])) {
       sortArrs[j] = arguments[j]
       sortFlag[j] = 0
       if (arguments[j].length !== arrMainLength) {
@@ -163,7 +163,7 @@ module.exports = function array_multisort(arr) {
       // If there are no sortComponents, then no more sorting is neeeded.
       // Copy the array back to the argument.
       if (sortComponents.length === 0) {
-        if (Object.prototype.toString.call(arguments[i]) === '[object Array]') {
+        if (Array.isArray(arguments[i])) {
           args[i] = sortArrs[i]
         } else {
           for (k in arguments[i]) {
@@ -274,7 +274,7 @@ module.exports = function array_multisort(arr) {
       if (sortComponents.length & 1) {
         sortComponents.push(j)
       }
-      if (Object.prototype.toString.call(arguments[i]) === '[object Array]') {
+      if (Array.isArray(arguments[i])) {
         args[i] = sortArrs[i]
       } else {
         for (j in arguments[i]) {

--- a/src/php/array/array_pad.js
+++ b/src/php/array/array_pad.js
@@ -17,7 +17,7 @@ module.exports = function array_pad(input, padSize, padValue) {
   let diff = 0
   let i = 0
 
-  if (Object.prototype.toString.call(input) === '[object Array]' && !isNaN(padSize)) {
+  if (Array.isArray(input) && !isNaN(padSize)) {
     newLength = padSize < 0 ? padSize * -1 : padSize
     diff = newLength - input.length
 

--- a/src/php/array/array_product.js
+++ b/src/php/array/array_product.js
@@ -9,7 +9,7 @@ module.exports = function array_product(input) {
   let product = 1
   let il = 0
 
-  if (Object.prototype.toString.call(input) !== '[object Array]') {
+  if (!Array.isArray(input)) {
     return null
   }
 

--- a/src/php/array/array_replace_recursive.js
+++ b/src/php/array/array_replace_recursive.js
@@ -17,7 +17,7 @@ module.exports = function array_replace_recursive(arr) {
   // Although docs state that the arguments are passed in by reference,
   // it seems they are not altered, but rather the copy that is returned
   // So we make a copy here, instead of acting on arr itself
-  if (Object.prototype.toString.call(arr) === '[object Array]') {
+  if (Array.isArray(arr)) {
     retObj = []
     for (p in arr) {
       retObj.push(arr[p])

--- a/src/php/array/array_reverse.js
+++ b/src/php/array/array_reverse.js
@@ -5,7 +5,7 @@ module.exports = function array_reverse(array, preserveKeys) {
   //   example 1: array_reverse( [ 'php', '4.0', ['green', 'red'] ], true)
   //   returns 1: { 2: ['green', 'red'], 1: '4.0', 0: 'php'}
 
-  const isArray = Object.prototype.toString.call(array) === '[object Array]'
+  const isArray = Array.isArray(array)
   const tmpArr = preserveKeys ? {} : []
   let key
 

--- a/src/php/array/array_slice.js
+++ b/src/php/array/array_slice.js
@@ -20,7 +20,7 @@ module.exports = function array_slice(arr, offst, lgth, preserveKeys) {
 
   let key = ''
 
-  if (Object.prototype.toString.call(arr) !== '[object Array]' || (preserveKeys && offst !== 0)) {
+  if (!Array.isArray(arr) || (preserveKeys && offst !== 0)) {
     // Assoc. array as input or if required as output
     let lgt = 0
     const newAssoc = {}

--- a/src/php/array/array_splice.js
+++ b/src/php/array/array_splice.js
@@ -49,7 +49,7 @@ module.exports = function array_splice(arr, offst, lgth, replacement) {
     lgth = (offst >= 0 ? arr.length - offst : -offst) + lgth
   }
 
-  if (Object.prototype.toString.call(arr) !== '[object Array]') {
+  if (!Array.isArray(arr)) {
     /* if (arr.length !== undefined) {
      // Deal with array-like objects as input
     delete arr.length;

--- a/src/php/array/array_udiff.js
+++ b/src/php/array/array_udiff.js
@@ -16,12 +16,7 @@ module.exports = function array_udiff(arr1) {
 
   const $global = typeof window !== 'undefined' ? window : global
 
-  cb =
-    typeof cb === 'string'
-      ? $global[cb]
-      : Object.prototype.toString.call(cb) === '[object Array]'
-        ? $global[cb[0]][cb[1]]
-        : cb
+  cb = typeof cb === 'string' ? $global[cb] : Array.isArray(cb) ? $global[cb[0]][cb[1]] : cb
 
   arr1keys: for (k1 in arr1) {
     for (i = 1; i < arglm1; i++) {

--- a/src/php/array/array_udiff_assoc.js
+++ b/src/php/array/array_udiff_assoc.js
@@ -14,12 +14,7 @@ module.exports = function array_udiff_assoc(arr1) {
 
   const $global = typeof window !== 'undefined' ? window : global
 
-  cb =
-    typeof cb === 'string'
-      ? $global[cb]
-      : Object.prototype.toString.call(cb) === '[object Array]'
-        ? $global[cb[0]][cb[1]]
-        : cb
+  cb = typeof cb === 'string' ? $global[cb] : Array.isArray(cb) ? $global[cb[0]][cb[1]] : cb
 
   arr1keys: for (k1 in arr1) {
     for (i = 1; i < arglm1; i++) {

--- a/src/php/array/array_udiff_uassoc.js
+++ b/src/php/array/array_udiff_uassoc.js
@@ -18,19 +18,9 @@ module.exports = function array_udiff_uassoc(arr1) {
 
   const $global = typeof window !== 'undefined' ? window : global
 
-  cb =
-    typeof cb === 'string'
-      ? $global[cb]
-      : Object.prototype.toString.call(cb) === '[object Array]'
-        ? $global[cb[0]][cb[1]]
-        : cb
+  cb = typeof cb === 'string' ? $global[cb] : Array.isArray(cb) ? $global[cb[0]][cb[1]] : cb
 
-  cb0 =
-    typeof cb0 === 'string'
-      ? $global[cb0]
-      : Object.prototype.toString.call(cb0) === '[object Array]'
-        ? $global[cb0[0]][cb0[1]]
-        : cb0
+  cb0 = typeof cb0 === 'string' ? $global[cb0] : Array.isArray(cb0) ? $global[cb0[0]][cb0[1]] : cb0
 
   arr1keys: for (k1 in arr1) {
     for (i = 1; i < arglm2; i++) {

--- a/src/php/array/array_uintersect.js
+++ b/src/php/array/array_uintersect.js
@@ -18,12 +18,7 @@ module.exports = function array_uintersect(arr1) {
 
   const $global = typeof window !== 'undefined' ? window : global
 
-  cb =
-    typeof cb === 'string'
-      ? $global[cb]
-      : Object.prototype.toString.call(cb) === '[object Array]'
-        ? $global[cb[0]][cb[1]]
-        : cb
+  cb = typeof cb === 'string' ? $global[cb] : Array.isArray(cb) ? $global[cb[0]][cb[1]] : cb
 
   arr1keys: for (k1 in arr1) {
     arrs: for (i = 1; i < arglm1; i++) {

--- a/src/php/array/array_uintersect_uassoc.js
+++ b/src/php/array/array_uintersect_uassoc.js
@@ -18,19 +18,9 @@ module.exports = function array_uintersect_uassoc(arr1) {
 
   const $global = typeof window !== 'undefined' ? window : global
 
-  cb =
-    typeof cb === 'string'
-      ? $global[cb]
-      : Object.prototype.toString.call(cb) === '[object Array]'
-        ? $global[cb[0]][cb[1]]
-        : cb
+  cb = typeof cb === 'string' ? $global[cb] : Array.isArray(cb) ? $global[cb[0]][cb[1]] : cb
 
-  cb0 =
-    typeof cb0 === 'string'
-      ? $global[cb0]
-      : Object.prototype.toString.call(cb0) === '[object Array]'
-        ? $global[cb0[0]][cb0[1]]
-        : cb0
+  cb0 = typeof cb0 === 'string' ? $global[cb0] : Array.isArray(cb0) ? $global[cb0[0]][cb0[1]] : cb0
 
   arr1keys: for (k1 in arr1) {
     arrs: for (i = 1; i < arglm2; i++) {

--- a/src/php/array/array_walk_recursive.js
+++ b/src/php/array/array_walk_recursive.js
@@ -18,7 +18,7 @@ module.exports = function array_walk_recursive(array, funcname, userdata) {
 
   for (const key in array) {
     // apply "funcname" recursively only on arrays
-    if (Object.prototype.toString.call(array[key]) === '[object Array]') {
+    if (Array.isArray(array[key])) {
       const funcArgs = [array[key], funcname]
       if (arguments.length > 2) {
         funcArgs.push(userdata)

--- a/src/php/array/current.js
+++ b/src/php/array/current.js
@@ -30,7 +30,7 @@ module.exports = function current(arr) {
   }
   const arrpos = pointers.indexOf(arr)
   const cursor = pointers[arrpos + 1]
-  if (Object.prototype.toString.call(arr) === '[object Array]') {
+  if (Array.isArray(arr)) {
     return arr[cursor] || false
   }
   let ct = 0

--- a/src/php/array/each.js
+++ b/src/php/array/each.js
@@ -32,7 +32,7 @@ module.exports = function each(arr) {
   const cursor = pointers[arrpos + 1]
   let pos = 0
 
-  if (Object.prototype.toString.call(arr) !== '[object Array]') {
+  if (!Array.isArray(arr)) {
     let ct = 0
     for (const k in arr) {
       if (ct === cursor) {

--- a/src/php/array/end.js
+++ b/src/php/array/end.js
@@ -35,7 +35,7 @@ module.exports = function end(arr) {
     pointers.push(arr, 0)
   }
   const arrpos = pointers.indexOf(arr)
-  if (Object.prototype.toString.call(arr) !== '[object Array]') {
+  if (!Array.isArray(arr)) {
     let ct = 0
     let val
     for (const k in arr) {

--- a/src/php/array/key.js
+++ b/src/php/array/key.js
@@ -33,7 +33,7 @@ module.exports = function key(arr) {
     pointers.push(arr, 0)
   }
   const cursor = pointers[pointers.indexOf(arr) + 1]
-  if (Object.prototype.toString.call(arr) !== '[object Array]') {
+  if (!Array.isArray(arr)) {
     let ct = 0
     for (const k in arr) {
       if (ct === cursor) {

--- a/src/php/array/next.js
+++ b/src/php/array/next.js
@@ -32,7 +32,7 @@ module.exports = function next(arr) {
   }
   const arrpos = pointers.indexOf(arr)
   const cursor = pointers[arrpos + 1]
-  if (Object.prototype.toString.call(arr) !== '[object Array]') {
+  if (!Array.isArray(arr)) {
     let ct = 0
     for (const k in arr) {
       if (ct === cursor + 1) {

--- a/src/php/array/prev.js
+++ b/src/php/array/prev.js
@@ -31,7 +31,7 @@ module.exports = function prev(arr) {
   if (pointers.indexOf(arr) === -1 || cursor === 0) {
     return false
   }
-  if (Object.prototype.toString.call(arr) !== '[object Array]') {
+  if (!Array.isArray(arr)) {
     let ct = 0
     for (const k in arr) {
       if (ct === cursor - 1) {

--- a/src/php/array/reset.js
+++ b/src/php/array/reset.js
@@ -30,7 +30,7 @@ module.exports = function reset(arr) {
     pointers.push(arr, 0)
   }
   const arrpos = pointers.indexOf(arr)
-  if (Object.prototype.toString.call(arr) !== '[object Array]') {
+  if (!Array.isArray(arr)) {
     for (const k in arr) {
       if (pointers.indexOf(arr) === -1) {
         pointers.push(arr, 0)

--- a/src/php/array/uasort.js
+++ b/src/php/array/uasort.js
@@ -26,7 +26,7 @@ module.exports = function uasort(inputArr, sorter) {
 
   if (typeof sorter === 'string') {
     sorter = this[sorter]
-  } else if (Object.prototype.toString.call(sorter) === '[object Array]') {
+  } else if (Array.isArray(sorter)) {
     sorter = this[sorter[0]][sorter[1]]
   }
 

--- a/src/php/array/usort.js
+++ b/src/php/array/usort.js
@@ -24,7 +24,7 @@ module.exports = function usort(inputArr, sorter) {
 
   if (typeof sorter === 'string') {
     sorter = this[sorter]
-  } else if (Object.prototype.toString.call(sorter) === '[object Array]') {
+  } else if (Array.isArray(sorter)) {
     sorter = this[sorter[0]][sorter[1]]
   }
 

--- a/src/php/funchand/call_user_func_array.js
+++ b/src/php/funchand/call_user_func_array.js
@@ -27,7 +27,7 @@ module.exports = function call_user_func_array(cb, parameters) {
     } else if (cb.match(validJSFunctionNamePattern)) {
       func = new Function(null, 'return ' + cb)()
     }
-  } else if (Object.prototype.toString.call(cb) === '[object Array]') {
+  } else if (Array.isArray(cb)) {
     if (typeof cb[0] === 'string') {
       if (cb[0].match(validJSFunctionNamePattern)) {
         // biome-ignore lint/security/noGlobalEval: needed for PHP port

--- a/src/php/math/is_finite.js
+++ b/src/php/math/is_finite.js
@@ -16,7 +16,7 @@ module.exports = function is_finite(val) {
 
   // Some warnings for maximum PHP compatibility
   if (typeof val === 'object') {
-    warningType = Object.prototype.toString.call(val) === '[object Array]' ? 'array' : 'object'
+    warningType = Array.isArray(val) ? 'array' : 'object'
   } else if (typeof val === 'string' && !val.match(/^[+-]?\d/)) {
     // simulate PHP's behaviour: '-9a' doesn't give a warning, but 'a9' does.
     warningType = 'string'

--- a/src/php/math/is_infinite.js
+++ b/src/php/math/is_infinite.js
@@ -16,7 +16,7 @@ module.exports = function is_infinite(val) {
 
   // Some warnings for maximum PHP compatibility
   if (typeof val === 'object') {
-    warningType = Object.prototype.toString.call(val) === '[object Array]' ? 'array' : 'object'
+    warningType = Array.isArray(val) ? 'array' : 'object'
   } else if (typeof val === 'string' && !val.match(/^[+-]?\d/)) {
     // simulate PHP's behaviour: '-9a' doesn't give a warning, but 'a9' does.
     warningType = 'string'

--- a/src/php/math/is_nan.js
+++ b/src/php/math/is_nan.js
@@ -15,7 +15,7 @@ module.exports = function is_nan(val) {
 
   // Some errors for maximum PHP compatibility
   if (typeof val === 'object') {
-    warningType = Object.prototype.toString.call(val) === '[object Array]' ? 'array' : 'object'
+    warningType = Array.isArray(val) ? 'array' : 'object'
   } else if (typeof val === 'string' && !val.match(/^[+-]?\d/)) {
     // simulate PHP's behaviour: '-9a' doesn't give a warning, but 'a9' does.
     warningType = 'string'

--- a/src/php/math/max.js
+++ b/src/php/math/max.js
@@ -24,7 +24,7 @@ module.exports = function max() {
   const argv = arguments
   const argc = argv.length
   const _obj2Array = function (obj) {
-    if (Object.prototype.toString.call(obj) === '[object Array]') {
+    if (Array.isArray(obj)) {
       return obj
     } else {
       const ar = []

--- a/src/php/math/min.js
+++ b/src/php/math/min.js
@@ -24,7 +24,7 @@ module.exports = function min() {
   const argv = arguments
   const argc = argv.length
   const _obj2Array = function (obj) {
-    if (Object.prototype.toString.call(obj) === '[object Array]') {
+    if (Array.isArray(obj)) {
       return obj
     }
     const ar = []

--- a/src/php/strings/implode.js
+++ b/src/php/strings/implode.js
@@ -20,7 +20,7 @@ module.exports = function implode(glue, pieces) {
   }
 
   if (typeof pieces === 'object') {
-    if (Object.prototype.toString.call(pieces) === '[object Array]') {
+    if (Array.isArray(pieces)) {
       return pieces.join(glue)
     }
     for (i in pieces) {

--- a/src/php/strings/setlocale.js
+++ b/src/php/strings/setlocale.js
@@ -334,7 +334,7 @@ module.exports = function setlocale(category, locale) {
 
   if (locale === null || locale === '') {
     locale = getenv(category) || getenv('LANG')
-  } else if (Object.prototype.toString.call(locale) === '[object Array]') {
+  } else if (Array.isArray(locale)) {
     for (i = 0; i < locale.length; i++) {
       if (!(locale[i] in $locutus.php.locales)) {
         if (i === locale.length - 1) {

--- a/src/php/strings/str_ireplace.js
+++ b/src/php/strings/str_ireplace.js
@@ -30,7 +30,7 @@ module.exports = function str_ireplace(search, replace, subject, countObj) {
   let oi = ''
   let ofjl = ''
   let os = subject
-  const osa = Object.prototype.toString.call(os) === '[object Array]'
+  const osa = Array.isArray(os)
   // var sa = ''
 
   if (typeof search === 'object') {
@@ -64,9 +64,9 @@ module.exports = function str_ireplace(search, replace, subject, countObj) {
   temp = ''
   f = [].concat(search)
   r = [].concat(replace)
-  ra = Object.prototype.toString.call(r) === '[object Array]'
+  ra = Array.isArray(r)
   s = subject
-  // sa = Object.prototype.toString.call(s) === '[object Array]'
+  // sa = Array.isArray(s)
   s = [].concat(s)
   os = [].concat(os)
 

--- a/src/php/strings/str_replace.js
+++ b/src/php/strings/str_replace.js
@@ -41,8 +41,8 @@ module.exports = function str_replace(search, replace, subject, countObj) {
   const f = [].concat(search)
   let r = [].concat(replace)
   let s = subject
-  let ra = Object.prototype.toString.call(r) === '[object Array]'
-  const sa = Object.prototype.toString.call(s) === '[object Array]'
+  let ra = Array.isArray(r)
+  const sa = Array.isArray(s)
   s = [].concat(s)
 
   const $global = typeof window !== 'undefined' ? window : global
@@ -58,7 +58,7 @@ module.exports = function str_replace(search, replace, subject, countObj) {
     }
     temp = ''
     r = [].concat(replace)
-    ra = Object.prototype.toString.call(r) === '[object Array]'
+    ra = Array.isArray(r)
   }
 
   if (typeof countObj !== 'undefined') {

--- a/src/php/var/is_array.js
+++ b/src/php/var/is_array.js
@@ -36,7 +36,7 @@ module.exports = function is_array(mixedVar) {
     return name[1]
   }
   const _isArray = function (mixedVar) {
-    // return Object.prototype.toString.call(mixedVar) === '[object Array]';
+    // return Array.isArray(mixedVar);
     // The above works, but let's do the even more stringent approach:
     // (since Object.prototype.toString could be overridden)
     // Null, Not an object, no length property so couldn't be an Array (or String)

--- a/src/php/var/is_callable.js
+++ b/src/php/var/is_callable.js
@@ -59,7 +59,7 @@ module.exports = function is_callable(mixedVar, syntaxOnly, callableName) {
   } else if (typeof mixedVar === 'function') {
     return true
   } else if (
-    Object.prototype.toString.call(mixedVar) === '[object Array]' &&
+    Array.isArray(mixedVar) &&
     mixedVar.length === 2 &&
     typeof mixedVar[0] === 'object' &&
     typeof mixedVar[1] === 'string'

--- a/src/php/var/is_object.js
+++ b/src/php/var/is_object.js
@@ -10,7 +10,7 @@ module.exports = function is_object(mixedVar) {
   //   example 3: is_object(null)
   //   returns 3: false
 
-  if (Object.prototype.toString.call(mixedVar) === '[object Array]') {
+  if (Array.isArray(mixedVar)) {
     return false
   }
   return mixedVar !== null && typeof mixedVar === 'object'

--- a/src/php/var/print_r.js
+++ b/src/php/var/print_r.js
@@ -34,7 +34,7 @@ module.exports = function print_r(array, returnVal) {
     if (typeof obj === 'object' && obj !== null && obj.constructor) {
       str += 'Array\n' + basePad + '(\n'
       for (const key in obj) {
-        if (Object.prototype.toString.call(obj[key]) === '[object Array]') {
+        if (Array.isArray(obj[key])) {
           str += thickPad
           str += '['
           str += key


### PR DESCRIPTION
## Summary
Modernizes array checking across 43 PHP function files by replacing the verbose pattern with the standard ES5+ method.

**Before:**
```js
Object.prototype.toString.call(arr) === '[object Array]'
```

**After:**
```js
Array.isArray(arr)
```

## Why
- `Array.isArray()` is the standard method for checking arrays (ES5, 2009)
- More readable and concise
- Semantically correct (purpose is clear from name)
- Addresses partial backlog item "Have _one_ way of checking pure JS arrays"

## Test plan
- [x] All 981 tests pass (`yarn check`)
- [x] Verified no remaining `[object Array]` patterns in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)