### PR TITLE
feat(website): Add Rosetta Stone cross-language links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Here are a few pointers that could save us from disappointment, we'll try to kee
 //   returns 1: "bar"
 ```
 
+11. **Rosetta Stone mappings**: If your function has semantic equivalents in other languages (e.g., PHP's `strlen` ↔ C's `strlen` ↔ Ruby's `length`), add it to `website/source/_data/rosetta.yml`. This enables cross-language navigation on the website.
+
 Verification steps (for new or changed functions):
 
 - `yarn test:parity php/<category>/<function>` (or the relevant language)

--- a/CORE_MAINTAINER.md
+++ b/CORE_MAINTAINER.md
@@ -47,6 +47,7 @@ Note that for any task, it's important to first get ample context. Search past i
     - Validate the work (tests, browser checks, etc.)
     - Run `yarn check`
     - Update documentation if needed
+    - **For new functions**: Check if semantic equivalents exist in other languages and update `website/source/_data/rosetta.yml`
     - **For website changes**: After merge, verify the live site at https://locutus.io using Playwright MCP
 10. Release recently merged PRs that contain new/changed functions (not just build tools, tests, or docs).
 11. Log iteration results in `docs/prompts/LOG.md`.
@@ -67,3 +68,4 @@ Note that for any task, it's important to first get ample context. Search past i
 - Biome unsafe fixes can break code: always test after auto-fix.
 - `eval()` is sometimes necessary: suppress with explanation, don't fight it.
 - **Batch related work**: Accumulate related changes before creating a PR. For expansion, aim for 10+ functions per PR to avoid noise.
+- **Rosetta Stone mappings**: When adding functions, check `website/source/_data/rosetta.yml` for semantic equivalents (e.g., PHP `strtolower` ↔ Ruby `downcase` ↔ Go `ToLower`). This enables cross-language discovery on the website.

--- a/website/source/_data/rosetta.yml
+++ b/website/source/_data/rosetta.yml
@@ -1,0 +1,301 @@
+# Rosetta Stone Mappings
+# Maps semantically equivalent functions across languages.
+# When adding a new function, check if an equivalent exists and add it here.
+# Format: group_name -> list of "language/category/function" paths
+#
+# IMPORTANT: Keep this file updated when adding functions!
+# See CONTRIBUTING.md for details.
+
+# =============================================================================
+# STRING OPERATIONS
+# =============================================================================
+
+string_length:
+  - php/strings/strlen
+  - c/string/strlen
+  - ruby/String/length
+
+string_lowercase:
+  - php/strings/strtolower
+  - ruby/String/downcase
+  - golang/strings/ToLower
+
+string_uppercase:
+  - php/strings/strtoupper
+  - ruby/String/upcase
+  - golang/strings/ToUpper
+
+string_trim:
+  - php/strings/trim
+  - ruby/String/strip
+  - golang/strings/TrimSpace
+  - golang/strings/Trim
+
+string_rtrim:
+  - php/strings/rtrim
+  - php/strings/chop
+  - ruby/String/chop
+  - ruby/String/chomp
+
+string_contains:
+  - golang/strings/Contains
+  - ruby/String/include
+
+string_starts_with:
+  - golang/strings/HasPrefix
+  - ruby/String/start_with
+
+string_ends_with:
+  - golang/strings/HasSuffix
+  - ruby/String/end_with
+
+string_reverse:
+  - php/strings/strrev
+  - ruby/String/reverse
+
+string_split:
+  - php/strings/explode
+  - golang/strings/Split
+
+string_join:
+  - php/strings/implode
+  - golang/strings/Join
+
+string_replace:
+  - php/strings/str_replace
+  - golang/strings/Replace
+
+string_index:
+  - php/strings/strpos
+  - golang/strings/Index
+  - golang/strings/Index2
+
+string_last_index:
+  - php/strings/strrpos
+  - golang/strings/LastIndex
+
+string_repeat:
+  - php/strings/str_repeat
+  - golang/strings/Repeat
+
+string_capitalize:
+  - php/strings/ucfirst
+  - ruby/String/capitalize
+
+string_compare:
+  - php/strings/strcmp
+  - c/string/strcmp
+  - golang/strings/Compare
+
+string_substring_search:
+  - php/strings/strstr
+  - c/string/strstr
+
+string_char_search:
+  - php/strings/strchr
+  - c/string/strchr
+
+string_count:
+  - php/strings/substr_count
+  - golang/strings/Count
+
+# =============================================================================
+# MATH OPERATIONS
+# =============================================================================
+
+math_sqrt:
+  - php/math/sqrt
+  - python/math/sqrt
+  - ruby/Math/sqrt
+
+math_exp:
+  - php/math/exp
+  - python/math/exp
+  - ruby/Math/exp
+
+math_log:
+  - php/math/log
+  - python/math/log
+  - ruby/Math/log
+
+math_log10:
+  - php/math/log10
+  - python/math/log10
+  - ruby/Math/log10
+
+math_log2:
+  - python/math/log2
+  - ruby/Math/log2
+
+math_sin:
+  - php/math/sin
+  - ruby/Math/sin
+
+math_cos:
+  - php/math/cos
+  - ruby/Math/cos
+
+math_tan:
+  - php/math/tan
+  - ruby/Math/tan
+
+math_asin:
+  - php/math/asin
+  - ruby/Math/asin
+
+math_acos:
+  - php/math/acos
+  - ruby/Math/acos
+
+math_atan:
+  - php/math/atan
+  - ruby/Math/atan
+
+math_sinh:
+  - php/math/sinh
+  - ruby/Math/sinh
+
+math_cosh:
+  - php/math/cosh
+  - ruby/Math/cosh
+
+math_tanh:
+  - php/math/tanh
+  - ruby/Math/tanh
+
+math_ceil:
+  - php/math/ceil
+  - python/math/ceil
+
+math_floor:
+  - php/math/floor
+  - python/math/floor
+
+math_abs:
+  - php/math/abs
+  - c/math/abs
+
+math_fabs:
+  - python/math/fabs
+
+math_pow:
+  - php/math/pow
+  - python/math/pow
+
+math_cbrt:
+  - ruby/Math/cbrt
+
+math_trunc:
+  - python/math/trunc
+
+math_factorial:
+  - python/math/factorial
+
+math_gcd:
+  - python/math/gcd
+
+math_isfinite:
+  - php/math/is_finite
+  - python/math/isfinite
+
+math_isinf:
+  - php/math/is_infinite
+  - python/math/isinf
+
+math_isnan:
+  - php/math/is_nan
+  - python/math/isnan
+
+# =============================================================================
+# CHARACTER TYPE CHECKING
+# =============================================================================
+
+char_isalnum:
+  - php/ctype/ctype_alnum
+  - c/ctype/isalnum
+
+char_isalpha:
+  - php/ctype/ctype_alpha
+  - c/ctype/isalpha
+
+char_isdigit:
+  - php/ctype/ctype_digit
+  - c/ctype/isdigit
+
+char_islower:
+  - php/ctype/ctype_lower
+  - c/ctype/islower
+
+char_isupper:
+  - php/ctype/ctype_upper
+  - c/ctype/isupper
+
+char_isspace:
+  - php/ctype/ctype_space
+  - c/ctype/isspace
+
+char_tolower:
+  - c/ctype/tolower
+
+char_toupper:
+  - c/ctype/toupper
+
+# =============================================================================
+# TYPE CONVERSION
+# =============================================================================
+
+string_to_int:
+  - php/var/intval
+  - c/stdlib/atoi
+  - golang/strconv/Atoi
+
+int_to_string:
+  - golang/strconv/Itoa
+
+string_to_float:
+  - c/stdlib/atof
+
+parse_int:
+  - golang/strconv/ParseInt
+
+format_int:
+  - golang/strconv/FormatInt
+
+parse_bool:
+  - golang/strconv/ParseBool
+
+format_bool:
+  - golang/strconv/FormatBool
+
+# =============================================================================
+# ARRAY/COLLECTION OPERATIONS
+# =============================================================================
+
+array_first:
+  - php/array/reset
+  - ruby/Array/first
+
+array_last:
+  - php/array/end
+  - ruby/Array/last
+
+array_unique:
+  - php/array/array_unique
+  - ruby/Array/uniq
+
+array_flatten:
+  - ruby/Array/flatten
+
+array_compact:
+  - ruby/Array/compact
+
+array_sample:
+  - ruby/Array/sample
+
+# =============================================================================
+# FORMATTING
+# =============================================================================
+
+sprintf:
+  - php/strings/sprintf
+  - c/stdio/sprintf

--- a/website/themes/icarus/layout/function.ejs
+++ b/website/themes/icarus/layout/function.ejs
@@ -16,6 +16,66 @@
           <% }) %>
         </div>
       <% } %>
+
+      <%
+      // Rosetta Stone: Find equivalent functions in other languages
+      // 1. Exact name matches (same function name across languages)
+      // 2. Semantic equivalents from website/source/_data/rosetta.yml
+      var rosettaLinks = [];
+      var currentPath = page.language + '/' + page.category + '/' + page.function;
+      var seenPaths = {};
+      seenPaths[currentPath] = true;
+
+      // Helper to add a link if not already seen
+      function addLink(path) {
+        if (seenPaths[path]) return;
+        seenPaths[path] = true;
+        var parts = path.split('/');
+        if (parts.length === 3) {
+          site.pages.find({ type: 'function', language: parts[0], category: parts[1], function: parts[2] }).each(function(fn) {
+            rosettaLinks.push({ page: fn, path: path });
+          });
+        }
+      }
+
+      // 1. Find exact name matches
+      site.pages.find({ type: 'function', function: page.function }).each(function(fn) {
+        if (fn.language !== page.language) {
+          addLink(fn.language + '/' + fn.category + '/' + fn.function);
+        }
+      });
+
+      // 2. Find semantic equivalents from rosetta.yml mappings
+      if (site.data && site.data.rosetta) {
+        Object.keys(site.data.rosetta).forEach(function(group) {
+          var paths = site.data.rosetta[group];
+          if (paths && paths.indexOf(currentPath) !== -1) {
+            paths.forEach(function(path) {
+              addLink(path);
+            });
+          }
+        });
+      }
+
+      // Sort by language order for consistent display
+      rosettaLinks.sort(function(a, b) {
+        var orderA = 99, orderB = 99;
+        site.pages.find({ type: 'language', language: a.page.language }).each(function(l) { orderA = l.order || 99; });
+        site.pages.find({ type: 'language', language: b.page.language }).each(function(l) { orderB = l.order || 99; });
+        if (orderA !== orderB) return orderA - orderB;
+        return a.page.function.localeCompare(b.page.function);
+      });
+      %>
+      <% if (rosettaLinks.length > 0) { %>
+        <div style="margin-top: 12px; padding: 10px 14px; background: #f8f9fa; border-left: 4px solid #007acc; border-radius: 4px;">
+          <span style="font-size: 13px; color: #555;">
+            <strong>Rosetta Stone:</strong>
+            <% rosettaLinks.forEach(function(link, idx) { %>
+              <a href="/<%= link.path %>/" style="margin-left: 8px;" title="<%= link.page.title %>"><%= link.page.language %>/<%= link.page.function %></a><% if (idx < rosettaLinks.length - 1) { %> ·<% } %>
+            <% }); %>
+          </span>
+        </div>
+      <% } %>
     </header>
 
     <div class="article-entry">


### PR DESCRIPTION
## Summary
- Adds "Rosetta Stone" section to function pages showing semantically equivalent functions in other languages
- **Dual lookup**: exact name matches + semantic equivalents via central mapping
- Links auto-update as new functions are added

## How it works

1. **Exact matches**: Functions with the same name (e.g., `sqrt` in PHP/Python/Ruby)
2. **Semantic equivalents**: Different names, same purpose (e.g., `strtolower` ↔ `downcase` ↔ `ToLower`)

The mapping is defined in `website/source/_data/rosetta.yml` with ~55 semantic groups:
- String operations (length, case, trim, split, join, replace, etc.)
- Math functions (sqrt, exp, log, trig, etc.)  
- Character type checking (isalpha, isdigit, etc.)
- Type conversion (atoi, Atoi, intval, etc.)
- Array operations (first, last, unique, etc.)

## Examples

| Function | Rosetta Stone shows |
|----------|---------------------|
| PHP `strtolower` | `golang/ToLower · ruby/downcase` |
| PHP `strlen` | `c/strlen · ruby/length` |
| PHP `explode` | `golang/Split` |
| PHP `trim` | `golang/TrimSpace · ruby/strip` |

## Files changed
- `website/source/_data/rosetta.yml` - Central mapping file
- `website/themes/icarus/layout/function.ejs` - Template with dual lookup
- `CONTRIBUTING.md` - Step 11: update rosetta.yml when adding functions
- `CORE_MAINTAINER.md` - Added to PR checklist and lessons learned

## Test plan
- [x] Tested locally with Playwright MCP
- [x] Verified exact matches work (sqrt: php, python, ruby)
- [x] Verified semantic equivalents work (strtolower → golang/ToLower, ruby/downcase)
- [x] `yarn check` passes (981 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)