### PR TITLE
chore: Add stricter Biome rules and improve CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
       - name: Lint
         run: |
           corepack yarn lint
+      - name: TypeScript Check
+        run: |
+          corepack yarn lint:ts
+      - name: Header Format Check
+        run: |
+          corepack yarn lint:headers
+      - name: No Stray JS Check
+        run: |
+          corepack yarn lint:no-stray-js
       - name: Build
         run: |
           corepack yarn build

--- a/biome.json
+++ b/biome.json
@@ -64,6 +64,9 @@
         "useIsNan": "error",
         "useValidTypeof": "error"
       },
+      "performance": {
+        "noAccumulatingSpread": "error"
+      },
       "security": { "noGlobalEval": "error" },
       "style": {
         "noYodaExpression": "error",
@@ -104,8 +107,12 @@
         "noUselessRegexBackrefs": "error",
         "noVar": "error",
         "noWith": "error",
+        "useAwait": "error",
         "useDefaultSwitchClauseLast": "error",
         "useIterableCallbackReturn": "error"
+      },
+      "nursery": {
+        "noFloatingPromises": "error"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fix:biome": "biome check --write .",
     "fix:headers": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON src/_util/formatHeaders.ts fix",
     "lint:headers": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON src/_util/formatHeaders.ts check",
-    "lint:no-stray-js": "bash -c 'found=$(find src test -name \"*.js\" | grep -vE \"^src/(c|golang|php|python|ruby)/|/index\\.js$|^test/browser/\"); if [ -n \"$found\" ]; then echo \"Stray .js files found (should be .ts):\"; echo \"$found\"; exit 1; fi'",
+    "lint:no-stray-js": "bash -c 'found=$(find src test -name \"*.js\" | grep -vE \"^src/(awk|c|clojure|elixir|golang|julia|lua|perl|php|python|r|ruby)/|/index\\.js$|^test/browser/\"); if [ -n \"$found\" ]; then echo \"Stray .js files found (should be .ts):\"; echo \"$found\"; exit 1; fi'",
     "lint:ts": "tsc --noEmit -p tsconfig.json",
     "fix:markdown": "remark {README,CONTRIBUTING}.md --output",
     "fix": "npm-run-all --serial 'fix:**'",

--- a/test/parity/index.ts
+++ b/test/parity/index.ts
@@ -475,7 +475,7 @@ async function main() {
     // Pull all images in parallel
     await pMap(
       Array.from(requiredImages),
-      async (image) => {
+      (image) => {
         if (ensureDockerImage(image)) {
           dockerDigests[image] = getDockerDigest(image)
         }


### PR DESCRIPTION
## Summary
- Add 3 new Biome linter rules to catch common issues:
  - `noAccumulatingSpread` (performance) - catches O(n²) reduce patterns like `arr.reduce((acc, v) => [...acc, v], [])`
  - `useAwait` (suspicious) - flags async functions that don't use await
  - `noFloatingPromises` (nursery) - catches unhandled promises
- CI now runs the full set of lint checks: `lint:ts`, `lint:headers`, `lint:no-stray-js`
- Update `lint:no-stray-js` to exclude new language directories (awk, clojure, elixir, julia, lua, perl, r)

## Test plan
- [x] `yarn check` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)