### PR TITLE
docs: formalize rolling browser compatibility policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ for fun experiments such as running PHP code directly in Node.js
   - [Running a single generated test](#running-a-single-generated-test)
   - [Custom tests](#custom-tests)
   - [Browser Playground](#browser-playground)
+  - [JavaScript Compatibility (Browser-Facing)](#javascript-compatibility-browser-facing)
 - [Commit](#commit)
 - [Releasing](#releasing)
 - [Website Development](#website-development)
@@ -180,6 +181,35 @@ If you just want a one-off browser run:
 ```bash
 yarn browser:test
 ```
+
+### JavaScript Compatibility (Browser-Facing)
+
+Locutus has two runtime targets:
+
+- Node package runtime: `engines.node >= 22`
+- Browser-facing runtime (website `Module JS` / `Standalone JS`, browser playground/tests):
+  `baseline widely available with downstream`
+
+For browser-facing code:
+
+- use syntax and built-ins compatible with the rolling Baseline target above
+- do not assume polyfills for website copy-paste snippets
+- if a function needs behavior outside this target, document it with a function header `note` comment
+
+Example exception note:
+
+```js
+// note 1: Uses Intl.Segmenter. For older targets, transpile and provide a compatible polyfill/fallback.
+```
+
+Quick local checks:
+
+```bash
+npx browserslist "baseline widely available with downstream"
+npx browserslist --coverage=global "baseline widely available with downstream"
+```
+
+This target is rolling by design and may shift as browser data and tooling updates.
 
 ## Commit
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ console.log(Contains('Locutus', 'cut'))
 // true
 ```
 
+## Browser Compatibility (Copy-Paste Snippets)
+
+Code shown on function pages (`Module JS` / `Standalone JS`) targets:
+
+- `baseline widely available with downstream`
+
+If your application targets older browsers, treat Locutus snippets like normal application code:
+
+1. transpile to your target (for example with TypeScript, Babel, SWC, or esbuild)
+2. add required polyfills for missing APIs in your environment
+3. validate with your own Browserslist target and browser test matrix
+
+Locutus does not inject polyfills into copy-paste snippets by default.
+
 ## Development
 
 Some guidelines and instructions can be found in [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
- add a browser-facing JavaScript compatibility policy to CONTRIBUTING
- define rolling target as `baseline widely available with downstream`
- require out-of-target behavior to be documented via function header `note`
- add README guidance for consumers targeting older browsers (transpile + polyfill + own browser matrix)

## Scope
- docs-only, no runtime behavior changes

## Notes
- this keeps Node runtime guidance (`engines.node >= 22`) explicit and separate from browser-facing snippet policy
