### PR TITLE
Fix regression in php/math{min. max} introduced in 3.x

### DIFF
--- a/src/php/math/max.ts
+++ b/src/php/math/max.ts
@@ -122,7 +122,7 @@ export function max(...args: PhpMinMaxValue[]): PhpMinMaxValue {
   }
 
   // If whole array is strings - handle it via sort and reverse for max
-  const stringOnly = values.every(i => typeof i === 'string')
+  const stringOnly = values.every((i) => typeof i === 'string')
   if (stringOnly) {
     return String(values.sort().reverse()[0])
   }

--- a/src/php/math/min.ts
+++ b/src/php/math/min.ts
@@ -122,11 +122,10 @@ export function min(...args: PhpMinMaxValue[]): PhpMinMaxValue {
   }
 
   // If whole array is strings - handle it via sort min
-  const stringOnly = values.every(i => typeof i === 'string')
+  const stringOnly = values.every((i) => typeof i === 'string')
   if (stringOnly) {
-    return String( values.sort()[0])
+    return String(values.sort()[0])
   }
-
 
   let result = first
 


### PR DESCRIPTION
## Description

Fix regression in php/math/{min, max} for arrays containing only strings. In 2.x this was handled properly whereas
this fails in 3.x
Added a special case if the whole array is an array of strings

Resolves #551 551

## Checklist

Yes,

- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/locutusjs/locutus/pulls) for
      the same update/change?
- [x] I have followed the guidelines in our
      [Contributing](https://github.com/locutusjs/locutus/blob/main/CONTRIBUTING.md) and e.g. bundled a test in the
      function header comments that fails before this PR, but passes after.
