### PR TITLE
test: prove selective parity target selection

### DIFF
--- a/docs/prompts/LOG.md
+++ b/docs/prompts/LOG.md
@@ -1329,3 +1329,18 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
 - Key learnings:
   - The selector does not need perfect minimality to be useful; conservative force-full rules keep the risky areas explicit.
   - Keeping smoke targets in a stable order is useful for CI readability and for avoiding accidental selector-test churn.
+
+### Iteration 73
+
+2026-03-06
+
+- **Area: Verification infrastructure**
+- Plan:
+  - Prove the selector end-to-end on a clean follow-up PR with one direct function change and one bounded helper cascade.
+- Progress:
+  - Chose `src/python/re/findall.ts` as the direct leaf target.
+  - Chose `src/php/_helpers/_arrayPointers.ts` as the shared helper target so the cascade stays bounded to PHP pointer helpers like `current`, `next`, `prev`, `reset`, `end`, `key`, and `each`.
+- Validation:
+  - Pending PR CI on the proof branch will be the source of truth; the selector PR itself could not prove selective behavior because it necessarily changed force-full files.
+- Key learnings:
+  - Selector proof has to happen after the workflow lands on `main`; otherwise the proof is masked by the selector's own force-full rules.

--- a/src/php/_helpers/_arrayPointers.ts
+++ b/src/php/_helpers/_arrayPointers.ts
@@ -19,6 +19,7 @@ const findPointerIndex = (pointers: PhpList<PhpInput>, target: PhpInput): number
 export function getPointerState<T>(target: PhpArrayLike<T>, initialize = true): PointerState | null {
   const runtime = ensurePhpRuntimeState()
   const pointers = runtime.pointers
+  // Store [target, cursor] pairs in one flat runtime list so pointer state stays bound to each array-like input.
   const pointerTarget: PhpInput = target
 
   let index = findPointerIndex(pointers, pointerTarget)

--- a/src/python/re/findall.ts
+++ b/src/python/re/findall.ts
@@ -36,6 +36,7 @@ export function findall(pattern: string | RegExp, source: string, flags: ReFinda
       out.push(match.slice(1).map((value) => value ?? ''))
     }
 
+    // Advance zero-width matches manually so the global scan always makes progress.
     if ((match[0] ?? '') === '') {
       if (regex.lastIndex >= input.length) {
         break


### PR DESCRIPTION
## Summary
- make one no-op direct function change in `python/re/findall`
- make one no-op shared helper change in `php/_helpers/_arrayPointers`
- prove the selective parity selector picks the leaf plus helper reverse dependents on PR CI

## Expected selector behavior
- direct target: `python/re/findall`
- cascade targets: `php/array/current`, `php/array/each`, `php/array/end`, `php/array/key`, `php/array/next`, `php/array/pos`, `php/array/prev`, `php/array/reset`
- plus the fixed smoke set

## Validation
- `node scripts/select-parity-targets.ts --base-ref origin/main --format json`
