### PR TITLE
chore: refresh github actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
@@ -24,7 +24,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |
@@ -106,9 +106,5 @@ jobs:
           corepack yarn website:ci
       - name: Website Deploy 🚀
         if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@3.7.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: website/public # The folder the action should deploy.
-          CLEAN: true # Automatically remove deleted files from the deploy branch
+        run: |
+          ./scripts/deploy-gh-pages.sh

--- a/.github/workflows/nightly-parity.yml
+++ b/.github/workflows/nightly-parity.yml
@@ -11,16 +11,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Ideas that will be planned and find their way into a release at one point
 
 Released: TBA. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.12...main).
 
+### CI
+
+- Refreshed GitHub Actions workflow pins to `checkout@v6`, `setup-node@v6`, and `cache@v5`, and replaced the Node 20-based Pages deploy action with a shell-based `gh-pages` deploy step ahead of the GitHub-hosted Node 24 cutoff.
+
 ## v3.0.12
 
 Released: 2026-03-11. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.11...v3.0.12).

--- a/docs/prompts/LOG.md
+++ b/docs/prompts/LOG.md
@@ -1687,3 +1687,24 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
   - `git status --short`
 - Key learnings:
   - The current release shape is strongest when it bundles one clear runtime addition with the maintainer-facing hardening work that reduced deploy and advisory risk during the same stretch.
+
+### Iteration 85
+
+2026-03-11
+
+- **Area: CI maintenance**
+- Plan:
+  - Remove the GitHub Actions Node 20 runtime warning before the June 2026 runner cutoff.
+  - Upgrade first-party action pins where official Node 24-capable majors already exist.
+  - Replace the third-party Pages deploy action if it is still tied to Node 20.
+- Progress:
+  - Verified from the official action metadata that `actions/checkout@v6`, `actions/setup-node@v6`, and `actions/cache@v5` run on `node24`.
+  - Verified that `JamesIves/github-pages-deploy-action@v4.7.3` still declares `using: node20`, so a version bump alone would not solve the warning.
+  - Replaced the workflow's Pages publish step with a small shell deploy script that force-pushes the generated `website/public` output onto `gh-pages` via a temporary worktree, preserving the existing generated-branch deployment model without relying on a Node-based action runtime.
+  - Updated both `ci.yml` and `nightly-parity.yml` so the Node 24-capable action pins are used consistently across PR, `main`, tag, and nightly runs.
+- Validation:
+  - `bash -n scripts/deploy-gh-pages.sh`
+  - `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/nightly-parity.yml')"`
+  - `DRY_RUN=1 ./scripts/deploy-gh-pages.sh`
+- Key learnings:
+  - The Pages deploy step was the only part of the workflow family that could not be fixed with a simple version bump; the actual Node 24-safe move was to replace the third-party action rather than shuffle to another Node 20-based deploy wrapper.

--- a/scripts/deploy-gh-pages.sh
+++ b/scripts/deploy-gh-pages.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+deploy_branch="${DEPLOY_BRANCH:-gh-pages}"
+deploy_remote="${DEPLOY_REMOTE:-origin}"
+source_dir="${DEPLOY_SOURCE_DIR:-$repo_root/website/public}"
+dry_run="${DRY_RUN:-0}"
+worktree_dir="$(mktemp -d "${TMPDIR:-/tmp}/locutus-gh-pages.XXXXXX")"
+worktree_branch="deploy-gh-pages-${RANDOM}-$$"
+default_commit_message="Deploy website from ${GITHUB_SHA:-local}"
+commit_message="${DEPLOY_COMMIT_MESSAGE:-$default_commit_message}"
+
+cleanup() {
+  git -C "$repo_root" worktree remove --force "$worktree_dir" >/dev/null 2>&1 || true
+  rm -rf "$worktree_dir"
+  git -C "$repo_root" branch -D "$worktree_branch" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+if [ ! -d "$source_dir" ]; then
+  printf 'Missing deploy source directory: %s\n' "$source_dir" >&2
+  exit 1
+fi
+
+if ! git ls-remote --exit-code --heads "$deploy_remote" "$deploy_branch" >/dev/null 2>&1; then
+  printf 'Missing remote branch %s/%s\n' "$deploy_remote" "$deploy_branch" >&2
+  exit 1
+fi
+
+git -C "$repo_root" fetch "$deploy_remote" "$deploy_branch"
+git -C "$repo_root" branch -f "$worktree_branch" "refs/remotes/$deploy_remote/$deploy_branch" >/dev/null
+git -C "$repo_root" worktree add --force --detach "$worktree_dir" "$worktree_branch" >/dev/null
+
+rsync -a --delete --exclude=.git --exclude=.git/ "$source_dir"/ "$worktree_dir"/
+
+if [ -z "$(git -C "$worktree_dir" status --short)" ]; then
+  printf 'No website changes to deploy\n'
+  exit 0
+fi
+
+git -C "$worktree_dir" config user.name "${GIT_AUTHOR_NAME:-github-actions[bot]}"
+git -C "$worktree_dir" config user.email "${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+git -C "$worktree_dir" add --all
+
+if [ -z "$(git -C "$worktree_dir" diff --cached --name-only)" ]; then
+  printf 'No staged website changes to deploy\n'
+  exit 0
+fi
+
+git -C "$worktree_dir" commit -m "$commit_message" >/dev/null
+
+if [ "$dry_run" = "1" ]; then
+  printf 'Dry run enabled; skipping push to %s/%s\n' "$deploy_remote" "$deploy_branch"
+  exit 0
+fi
+
+git -C "$worktree_dir" push --force "$deploy_remote" "HEAD:$deploy_branch"


### PR DESCRIPTION
## Summary
- bump GitHub-owned workflow actions to the current Node 24-capable majors
- replace the Node 20-based Pages deploy action with a shell-driven gh-pages deploy script
- log the workflow maintenance in the changelog and maintainer log

## Why
GitHub is warning that Node 20-based JavaScript actions will be forced onto Node 24 on June 2, 2026. Official first-party upgrades exist for `checkout`, `setup-node`, and `cache`, but the current Pages deploy action family still declares `node20`, so the actual safe move was to remove that dependency from CI.

## Validation
- `bash -n scripts/deploy-gh-pages.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/nightly-parity.yml')"`
- `DRY_RUN=1 ./scripts/deploy-gh-pages.sh`
- `~/code/dotfiles/bin/council.ts review`
- `corepack yarn check`
