### PR TITLE
fix: make release reruns idempotent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,14 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           npm install -g npm@^11.5.1
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            echo "npm package ${PACKAGE_NAME}@${PACKAGE_VERSION} is already published; skipping npm publish."
+            exit 0
+          fi
+
           cd dist/
           npm publish --access public --provenance
       - name: Website Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Ideas that will be planned and find their way into a release at one point
 
 Released: TBA. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.13...main).
 
+### CI
+
+- Made tag-release reruns idempotent on npm by skipping `npm publish` when the tagged package version is already published, so recovery reruns do not fail on duplicate publish attempts.
+
 ## v3.0.13
 
 Released: 2026-03-11. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.12...v3.0.13).

--- a/docs/prompts/LOG.md
+++ b/docs/prompts/LOG.md
@@ -1747,3 +1747,20 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
   - Pending tag and `main` workflow completion.
 - Key learnings:
   - This issue was small enough for a same-day merge-and-release, but still worth running through the standard `main` and tag workflow gates because it changes runtime error semantics in a verified function.
+
+### Iteration 88
+
+2026-03-11
+
+- **Area: CI release hardening**
+- Plan:
+  - Fix the tag-release workflow so rerunning a completed publish does not fail on npm duplicate-version errors.
+  - Keep first-run publish behavior unchanged.
+  - Validate the workflow syntax and the npm-version detection logic locally before opening a PR.
+- Progress:
+  - Investigated the failed `v3.0.13` tag rerun and confirmed the only failure was `npm publish` rejecting an already-published version after full parity had passed.
+  - Updated `.github/workflows/ci.yml` so the `Release` step checks whether `${name}@${version}` is already present on npm and exits successfully instead of retrying `npm publish`.
+- Validation:
+  - Pending local workflow validation and command-path verification.
+- Key learnings:
+  - Release reruns need idempotent external-side effects; package publication should be treated as “publish if missing” rather than “always publish.”


### PR DESCRIPTION
## Summary

This hardens the tag release path so rerunning a completed release does not fail on npm duplicate-version errors.

The immediate trigger was `v3.0.13`: the package was already published successfully, but the rerun reached the `Release` step again and failed only because npm refused to publish `3.0.13` a second time.

## What changed

- `ci.yml` now checks whether `${name}@${version}` already exists on npm before `npm publish`
- if the tagged version is already published, the workflow exits the `Release` step successfully instead of failing
- first-run publish behavior is unchanged

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"`
- local guard check for the real published version: `skip:locutus@3.0.13`
- local guard check for a fake unpublished version: `publish:locutus@9.9.9-codex-rerun-check`
