### PR TITLE
test: add runtime surface guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,17 @@ jobs:
         id: parity-targets
         run: |
           corepack yarn select:parity --base-ref origin/${{ github.event.pull_request.base.ref }} --github-output "$GITHUB_OUTPUT"
+      - name: Runtime surface guardrail (selective)
+        if: github.event_name == 'pull_request' && steps.parity-targets.outputs.runtime_surface_languages != ''
+        run: |
+          mapfile -t languages < <(printf '%s\n' "${{ steps.parity-targets.outputs.runtime_surface_languages }}" | sed '/^$/d')
+          printf 'Running runtime surface guardrail on %s languages\n' "${#languages[@]}"
+          printf '  %s\n' "${languages[@]}"
+          corepack yarn test:runtime-surface "${languages[@]}"
+      - name: Runtime surface guardrail (full)
+        if: github.event_name != 'pull_request'
+        run: |
+          corepack yarn test:runtime-surface
       - name: Parity tests (selective)
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/nightly-parity.yml
+++ b/.github/workflows/nightly-parity.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install Dependencies
         run: |
           corepack yarn
+      - name: Runtime surface guardrail
+        run: |
+          corepack yarn test:runtime-surface
       - name: Run full parity suite
         run: |
           corepack yarn test:parity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Ideas that will be planned and find their way into a release at one point
 
 Released: TBA. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.14...main).
 
+### Infrastructure
+
+- Added a parity-adjacent runtime-surface guardrail that discovers callable functions from the target PHP 8.3 Docker image, compares them against Locutus' shipped PHP surface, hard-fails on unclassified Locutus-only extras, and reports runtime-only functions as inspiration rather than CI failures.
+
 ## v3.0.14
 
 Released: 2026-03-11. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.13...v3.0.14).

--- a/docs/prompts/LOG.md
+++ b/docs/prompts/LOG.md
@@ -1280,6 +1280,16 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
   - Passing under `--all` is not enough for promotion; some functions still fail once native output shape and signature mismatches are exercised in the verified path.
   - The final bounded benefit here is small but real: keep the translator bug fix plus the three C functions that truly pass, and stop before this turns into a broader C/Perl parity project.
 
+### Iterations 71-80
+
+2026-03-10
+
+- Landed selective parity on PRs plus nightly full parity, and proved the selector behavior end-to-end with a dedicated follow-up PR.
+- Fixed the website `injectweb` case-insensitive path collision and released the result in `v3.0.10`.
+- Rebalanced from infrastructure into product work with a Rust `str` batch and a mixed hard-algorithms batch, then released `v3.0.11`.
+- Removed stale root dependencies, added a website-build verification harness, and upgraded the website feed stack under that new safety net.
+- Key pattern: use infra to buy confidence, then spend it quickly on product and release work instead of looping on tooling indefinitely.
+
 ### Iteration 71
 
 2026-03-06
@@ -1574,6 +1584,16 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
 - Key learnings:
   - The right way to de-risk website dependency upgrades is not a giant upgrade PR first; it is a narrow build/output contract that future website PRs must satisfy.
 
+### Iterations 81-90
+
+2026-03-12
+
+- Upgraded the remaining website feed dependency and then used that harness to burn down dependency and advisory debt across root and `website/`.
+- Added `golang/time/ParseInLocation`, released `v3.0.12`, fixed the GitHub Actions Node runtime deadline, and shipped an idempotent rerun-safe release workflow.
+- Fixed `php/array/array_values`, released `v3.0.13`, removed the PHP-8.3-incompatible `create_function`, released `v3.0.14`, and closed the linked GitHub advisory with the shipped fix.
+- Began the next parity-adjacent guardrail: runtime surface discovery from the parity container, with PHP 8.3 as the first live implementation.
+- Balance check: this block touched website, security, CI maintenance, releases, product expansion, and parity policy rather than over-concentrating on one backlog area.
+
 ### Iteration 81
 
 2026-03-10
@@ -1783,3 +1803,26 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
   - Pending tag workflow and production verification.
 - Key learnings:
   - Even when a fix intentionally removes one public helper, the project’s bump policy still treats isolated parity/security corrections as patch releases unless they change the package runtime/import model broadly.
+
+### Iteration 90
+
+2026-03-12
+
+- **Area: Parity infrastructure**
+- Plan:
+  - Add a generic runtime-surface guardrail beside parity, with adapter-owned discovery and classification instead of a PHP-only special case.
+  - Discover the live callable surface from the same Docker image used for parity and compare it against Locutus' exported surface.
+  - Hard-fail on unclassified Locutus-only extras while reporting runtime-only functions as inspiration instead of CI failures.
+- Progress:
+  - Extended the parity handler types with an optional `runtimeSurface` adapter capability.
+  - Added a generic runtime-surface comparison module and `scripts/check-runtime-surface.ts`.
+  - Implemented the first adapter-backed discovery path in `test/parity/lib/languages/php.ts`, using `php:8.3-cli` and an explicit allowlist for current intentional Locutus-only PHP extras.
+  - Added focused unit coverage in `test/util/runtime-surface.vitest.ts`.
+  - Wired the new guardrail into both PR/push CI and nightly parity workflows as a separate step from behavior parity.
+- Validation:
+  - `corepack yarn exec vitest run test/util/runtime-surface.vitest.ts`
+  - `corepack yarn lint:ts`
+  - `corepack yarn test:runtime-surface php`
+- Key learnings:
+  - The live PHP 8.3 container surface is already useful as both a guardrail and an idea backlog: this first pass found 24 intentional Locutus-only extras and 887 runtime-only functions worth treating as inspiration rather than failures.
+  - Keeping the classification policy on the language adapter itself makes the system generic enough for other runtimes without locking us into PHP-specific filenames or one-off scripts.

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test:module": "npm-run-all --serial build:dist test:module:smoke",
     "test:parity": "node test/parity/index.ts",
     "test:parity:php": "node test/parity/index.ts php",
+    "test:runtime-surface": "node scripts/check-runtime-surface.ts",
     "test:util": "vitest run test/util/",
     "test": "npm-run-all test:languages test:module",
     "website:install": "cd website && yarn",

--- a/scripts/check-runtime-surface.ts
+++ b/scripts/check-runtime-surface.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * Discover runtime surfaces from parity containers and compare them against the
+ * Locutus functions currently shipped for those languages.
+ */
+
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { checkDockerAvailable, ensureDockerImage } from '../test/parity/lib/docker.ts'
+import { getLanguageHandler, getSupportedLanguages } from '../test/parity/lib/languages/index.ts'
+import { findFunctionSources } from '../test/parity/lib/parser.ts'
+import {
+  compareRuntimeSurface,
+  formatRuntimeSurfaceReport,
+  resolveRuntimeSurfaceLanguages,
+} from '../test/parity/lib/runtime-surface.ts'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..')
+const SRC = join(ROOT, 'src')
+
+async function main() {
+  const filters = process.argv.slice(2)
+
+  if (!checkDockerAvailable()) {
+    console.error('Docker is required for runtime surface checks.')
+    process.exit(1)
+  }
+
+  const supportedLanguages = getSupportedLanguages()
+  const resolution = resolveRuntimeSurfaceLanguages(filters, supportedLanguages, (language) => {
+    const handler = getLanguageHandler(language)
+    return !!handler?.runtimeSurface
+  })
+
+  if (resolution.unknown.length) {
+    console.error(`Unknown language filter(s): ${resolution.unknown.join(', ')}`)
+    process.exit(1)
+  }
+
+  if (resolution.unavailable.length) {
+    console.error(`Runtime surface discovery is not implemented for: ${resolution.unavailable.join(', ')}`)
+    process.exit(1)
+  }
+
+  const runnableLanguages = resolution.selected
+
+  if (!runnableLanguages.length) {
+    const requested = filters.length ? filters.join(', ') : 'all supported languages'
+    console.error(`No runtime surface adapters are available for ${requested}.`)
+    process.exit(1)
+  }
+
+  let failed = false
+
+  for (const language of runnableLanguages) {
+    const handler = getLanguageHandler(language)
+    if (!handler?.runtimeSurface) {
+      continue
+    }
+
+    if (!ensureDockerImage(handler.dockerImage)) {
+      console.error(`Unable to pull Docker image for ${language}: ${handler.dockerImage}`)
+      failed = true
+      continue
+    }
+
+    const functions = findFunctionSources(SRC, language)
+    const runtimeSurface = await handler.runtimeSurface.discover()
+    const result = compareRuntimeSurface(functions, handler, runtimeSurface)
+
+    console.log(formatRuntimeSurfaceReport(result))
+    console.log('')
+
+    if (result.unexpectedExtras.length || result.duplicateEntries.length) {
+      failed = true
+    }
+  }
+
+  if (failed) {
+    process.exit(1)
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/scripts/select-parity-targets.ts
+++ b/scripts/select-parity-targets.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 import ts from 'typescript'
 
 import { Util } from '../src/_util/util.ts'
+import { getLanguageHandler, getSupportedLanguages } from '../test/parity/lib/languages/index.ts'
 import { findFunctions } from '../test/parity/lib/parser.ts'
 import type { FunctionInfo } from '../test/parity/lib/types.ts'
 
@@ -37,6 +38,11 @@ const FORCE_FULL_PATHS = new Set([
 ])
 
 const FORCE_FULL_PREFIXES = ['.github/workflows/', 'test/parity/lib/']
+const RUNTIME_SURFACE_FORCE_ALL_PATHS = new Set([
+  'scripts/check-runtime-surface.ts',
+  'test/parity/lib/runtime-surface.ts',
+  'test/util/runtime-surface.vitest.ts',
+])
 
 export interface ParitySelectionInput {
   changedFiles: string[]
@@ -205,6 +211,49 @@ function computeFullReasons(changedFiles: string[]): string[] {
   return [...new Set(reasons)]
 }
 
+function getRuntimeSurfaceLanguages(): string[] {
+  return getSupportedLanguages().filter((language) => {
+    const handler = getLanguageHandler(language)
+    return !!handler?.runtimeSurface
+  })
+}
+
+export function computeRuntimeSurfaceLanguages(changedFiles: string[]): string[] {
+  const normalized = [...new Set(changedFiles.map(normalizePath).filter(Boolean))].sort()
+  const allLanguages = getRuntimeSurfaceLanguages()
+
+  if (computeFullReasons(normalized).length > 0) {
+    return allLanguages
+  }
+
+  const selected = new Set<string>()
+
+  for (const changedFile of normalized) {
+    if (RUNTIME_SURFACE_FORCE_ALL_PATHS.has(changedFile)) {
+      return allLanguages
+    }
+
+    if (isLanguageHandlerPath(changedFile)) {
+      const language = changedFile.match(/^test\/parity\/lib\/languages\/([^/]+)\.ts$/)?.[1]
+      if (language && getLanguageHandler(language)?.runtimeSurface) {
+        selected.add(language)
+      }
+      continue
+    }
+
+    if (!isSourceModulePath(changedFile)) {
+      continue
+    }
+
+    const language = changedFile.split('/')[1]
+    if (language && getLanguageHandler(language)?.runtimeSurface) {
+      selected.add(language)
+    }
+  }
+
+  return [...selected].sort()
+}
+
 export function computeParitySelection(input: ParitySelectionInput): ParitySelection {
   const changedFiles = [...new Set(input.changedFiles.map(normalizePath).filter(Boolean))].sort()
   const functionInfos = input.functionInfos
@@ -318,11 +367,15 @@ export function formatSelection(selection: ParitySelection): string {
 }
 
 function writeGithubOutput(outputPath: string, selection: ParitySelection): void {
+  const runtimeSurfaceLanguages = computeRuntimeSurfaceLanguages(selection.changedFiles)
   const lines = [
     `mode=${selection.mode}`,
     `target_count=${selection.targets.length}`,
     'targets<<EOF',
     ...selection.targets,
+    'EOF',
+    'runtime_surface_languages<<EOF',
+    ...runtimeSurfaceLanguages,
     'EOF',
     'summary<<EOF',
     formatSelection(selection),

--- a/test/parity/lib/languages/php.ts
+++ b/test/parity/lib/languages/php.ts
@@ -2,8 +2,14 @@
  * PHP language handler for verification
  */
 
+import { runInDocker } from '../docker.ts'
 import { extractAssignedVar } from '../runner.ts'
 import type { LanguageHandler } from '../types.ts'
+
+const PHP_DISPLAY_NAME = 'PHP'
+const PHP_VERSION = '8.3'
+const PHP_DOCKER_IMAGE = 'php:8.3-cli'
+const PHP_PARITY_TARGET = `${PHP_DISPLAY_NAME} ${PHP_VERSION}`
 
 // Functions removed, deprecated, or unavailable in PHP 8.3 Docker image
 export const PHP_SKIP_LIST = new Set([
@@ -26,6 +32,58 @@ export const PHP_SKIP_LIST = new Set([
   // PHP language constructs (not callable as functions)
   'echo',
 ])
+
+const PHP_ALLOWED_RUNTIME_SURFACE_EXTRAS = new Map<string, string>([
+  ['bcadd', 'bcmath extension is not enabled in the base parity container'],
+  ['bccomp', 'bcmath extension is not enabled in the base parity container'],
+  ['bcdiv', 'bcmath extension is not enabled in the base parity container'],
+  ['bcmul', 'bcmath extension is not enabled in the base parity container'],
+  ['bcround', 'bcmath extension is not enabled in the base parity container'],
+  ['bcscale', 'bcmath extension is not enabled in the base parity container'],
+  ['bcsub', 'bcmath extension is not enabled in the base parity container'],
+  ['convert_cyr_string', 'removed in PHP 8.0 but intentionally retained as a legacy port'],
+  ['each', 'removed in PHP 8.0 but intentionally retained as a legacy port'],
+  ['echo', 'PHP language construct, not a callable runtime function'],
+  ['empty', 'PHP language construct, not a callable runtime function'],
+  ['gopher_parsedir', 'niche extension helper retained as an explicit Locutus port'],
+  ['i18n_loc_get_default', 'PECL intl helper retained as an explicit Locutus port'],
+  ['i18n_loc_set_default', 'PECL intl helper retained as an explicit Locutus port'],
+  ['is_binary', 'legacy PHP alias/helper retained as an explicit Locutus port'],
+  ['is_buffer', 'legacy PHP alias/helper retained as an explicit Locutus port'],
+  ['is_real', 'legacy PHP alias/helper retained as an explicit Locutus port'],
+  ['is_unicode', 'legacy PHP alias/helper retained as an explicit Locutus port'],
+  ['isset', 'PHP language construct, not a callable runtime function'],
+  ['money_format', 'removed in PHP 8.0 but intentionally retained as a legacy port'],
+  ['split', 'removed in PHP 7.0 but intentionally retained as a legacy port'],
+  ['sql_regcase', 'removed in PHP 7.0 but intentionally retained as a legacy port'],
+  ['xdiff_string_diff', 'xdiff extension is not enabled in the base parity container'],
+  ['xdiff_string_patch', 'xdiff extension is not enabled in the base parity container'],
+])
+
+function discoverPhpRuntimeSurface() {
+  const result = runInDocker(PHP_DOCKER_IMAGE, [
+    'php',
+    '-r',
+    'echo json_encode(array_values(get_defined_functions()["internal"]));',
+  ])
+
+  if (!result.success) {
+    throw new Error(result.error || 'Unable to discover PHP runtime surface')
+  }
+
+  const parsed = JSON.parse(result.output) as unknown
+  if (!Array.isArray(parsed) || !parsed.every((value) => typeof value === 'string')) {
+    throw new Error('PHP runtime surface output was not a string array')
+  }
+
+  const functions = [...new Set(parsed)].sort()
+
+  return {
+    language: 'php',
+    target: PHP_PARITY_TARGET,
+    functions,
+  }
+}
 
 // PHP constants that should not be quoted when passed as string arguments
 const PHP_CONSTANTS = new Set([
@@ -442,12 +500,17 @@ export const phpHandler: LanguageHandler = {
   translate: jsToPhp,
   normalize: normalizePhpOutput,
   skipList: PHP_SKIP_LIST,
-  dockerImage: 'php:8.3-cli',
-  displayName: 'PHP',
-  version: '8.3',
+  dockerImage: PHP_DOCKER_IMAGE,
+  displayName: PHP_DISPLAY_NAME,
+  version: PHP_VERSION,
   get parityValue() {
-    return `${this.displayName} ${this.version}`
+    return PHP_PARITY_TARGET
   },
   dockerCmd: (code: string) => ['php', '-r', code],
   mountRepo: true,
+  runtimeSurface: {
+    discover: discoverPhpRuntimeSurface,
+    getLocutusEntry: (func) => func.name,
+    allowedExtras: PHP_ALLOWED_RUNTIME_SURFACE_EXTRAS,
+  },
 }

--- a/test/parity/lib/parser.ts
+++ b/test/parity/lib/parser.ts
@@ -8,6 +8,14 @@ import type { Example, FunctionInfo } from './types.ts'
 
 const SOURCE_EXTENSIONS = ['.ts', '.js'] as const
 
+export interface FunctionSource {
+  path: string
+  language: string
+  category: string
+  name: string
+  fullPath: string
+}
+
 export function resolveFunctionSourcePath(srcDir: string, funcPath: string): string | null {
   for (const ext of SOURCE_EXTENSIONS) {
     const fullPath = join(srcDir, `${funcPath}${ext}`)
@@ -220,10 +228,11 @@ export async function parseFunctionWithUtil(
 }
 
 /**
- * Find all function files matching optional filter
+ * Find all function source files matching optional filter.
+ * Unlike `findFunctions`, this does not require examples to be present.
  */
-export function findFunctions(srcDir: string, filter?: string): FunctionInfo[] {
-  const functions: FunctionInfo[] = []
+export function findFunctionSources(srcDir: string, filter?: string): FunctionSource[] {
+  const functions: FunctionSource[] = []
 
   const languages = readdirSync(srcDir).filter((d) => {
     const stat = statSync(join(srcDir, d))
@@ -275,26 +284,44 @@ export function findFunctions(srcDir: string, filter?: string): FunctionInfo[] {
           continue
         }
 
-        const fullPath = join(catDir, file)
-        const examples = parseExamples(fullPath)
-        const dependsOn = parseDependsOn(fullPath)
-        const { verified, isImpossible } = parseVerified(fullPath)
-
-        if (examples.length > 0) {
-          functions.push({
-            path: funcPath,
-            language,
-            category,
-            name: funcName,
-            examples,
-            dependsOn,
-            verified,
-            isImpossible,
-          })
-        }
+        functions.push({
+          path: funcPath,
+          language,
+          category,
+          name: funcName,
+          fullPath: join(catDir, file),
+        })
       }
     }
   }
 
   return functions
+}
+
+/**
+ * Find all example-bearing functions matching optional filter.
+ */
+export function findFunctions(srcDir: string, filter?: string): FunctionInfo[] {
+  return findFunctionSources(srcDir, filter)
+    .map((func) => {
+      const examples = parseExamples(func.fullPath)
+      if (examples.length === 0) {
+        return null
+      }
+
+      const dependsOn = parseDependsOn(func.fullPath)
+      const { verified, isImpossible } = parseVerified(func.fullPath)
+
+      return {
+        path: func.path,
+        language: func.language,
+        category: func.category,
+        name: func.name,
+        examples,
+        dependsOn,
+        verified,
+        isImpossible,
+      }
+    })
+    .filter((func): func is FunctionInfo => func !== null)
 }

--- a/test/parity/lib/runtime-surface.ts
+++ b/test/parity/lib/runtime-surface.ts
@@ -1,0 +1,192 @@
+/**
+ * Runtime surface discovery and comparison utilities.
+ *
+ * These checks are parity-adjacent: they compare the functions Locutus ships
+ * for a language against the callable/runtime surface exposed by the parity
+ * target container for that language.
+ */
+
+import type {
+  FunctionInfo,
+  LanguageHandler,
+  RuntimeSurfaceAdapter,
+  RuntimeSurfaceExtra,
+  RuntimeSurfaceLocutusFunction,
+  RuntimeSurfaceSnapshot,
+} from './types.ts'
+
+export interface RuntimeSurfaceCheckResult {
+  language: string
+  target: string
+  runtimeSurface: RuntimeSurfaceSnapshot
+  locutusFunctions: number
+  locutusEntries: string[]
+  ignoredFunctions: string[]
+  duplicateEntries: string[]
+  allowedExtras: RuntimeSurfaceExtra[]
+  unexpectedExtras: string[]
+  runtimeOnly: string[]
+}
+
+export interface RuntimeSurfaceLanguageResolution {
+  selected: string[]
+  unknown: string[]
+  unavailable: string[]
+}
+
+export function resolveRuntimeSurfaceLanguages(
+  requestedLanguages: string[],
+  supportedLanguages: string[],
+  hasRuntimeSurface: (language: string) => boolean,
+): RuntimeSurfaceLanguageResolution {
+  if (!requestedLanguages.length) {
+    return {
+      selected: supportedLanguages.filter(hasRuntimeSurface),
+      unknown: [],
+      unavailable: [],
+    }
+  }
+
+  const supported = new Set(supportedLanguages)
+  const selected: string[] = []
+  const unknown: string[] = []
+  const unavailable: string[] = []
+
+  for (const language of requestedLanguages) {
+    if (!supported.has(language)) {
+      unknown.push(language)
+      continue
+    }
+
+    if (!hasRuntimeSurface(language)) {
+      unavailable.push(language)
+      continue
+    }
+
+    selected.push(language)
+  }
+
+  return {
+    selected: [...new Set(selected)],
+    unknown: [...new Set(unknown)].sort(),
+    unavailable: [...new Set(unavailable)].sort(),
+  }
+}
+
+export function collectLocutusSurfaceEntries(
+  functions: RuntimeSurfaceLocutusFunction[],
+  adapter: RuntimeSurfaceAdapter,
+): { entries: string[]; duplicates: string[]; ignoredFunctions: string[] } {
+  const entriesByName = new Map<string, string[]>()
+  const ignoredFunctions: string[] = []
+
+  for (const func of functions) {
+    const entry = adapter.getLocutusEntry(func)
+    if (!entry) {
+      ignoredFunctions.push(func.path)
+      continue
+    }
+
+    const paths = entriesByName.get(entry) ?? []
+    paths.push(func.path)
+    entriesByName.set(entry, paths)
+  }
+
+  const entries = [...entriesByName.keys()].sort()
+  const duplicates = [...entriesByName.entries()]
+    .filter(([, paths]) => paths.length > 1)
+    .map(([entry, paths]) => `${entry}: ${paths.join(', ')}`)
+    .sort()
+
+  return {
+    entries,
+    duplicates,
+    ignoredFunctions: ignoredFunctions.sort(),
+  }
+}
+
+export function compareRuntimeSurface(
+  functions: RuntimeSurfaceLocutusFunction[],
+  handler: LanguageHandler,
+  runtimeSurface: RuntimeSurfaceSnapshot,
+): RuntimeSurfaceCheckResult {
+  if (!handler.runtimeSurface) {
+    throw new Error(`Language ${handler.displayName} does not define a runtime surface adapter`)
+  }
+
+  const { entries, duplicates, ignoredFunctions } = collectLocutusSurfaceEntries(functions, handler.runtimeSurface)
+  const runtimeEntries = [...new Set(runtimeSurface.functions)].sort()
+  const runtimeSet = new Set(runtimeEntries)
+  const locutusSet = new Set(entries)
+  const allowedExtras: RuntimeSurfaceExtra[] = []
+  const unexpectedExtras: string[] = []
+
+  for (const entry of entries) {
+    if (runtimeSet.has(entry)) {
+      continue
+    }
+
+    const reason = handler.runtimeSurface.allowedExtras?.get(entry)
+    if (reason) {
+      allowedExtras.push({ name: entry, reason })
+      continue
+    }
+
+    unexpectedExtras.push(entry)
+  }
+
+  const runtimeOnly = runtimeEntries.filter((entry) => !locutusSet.has(entry))
+
+  return {
+    language: runtimeSurface.language,
+    target: runtimeSurface.target,
+    runtimeSurface: {
+      ...runtimeSurface,
+      functions: runtimeEntries,
+    },
+    locutusFunctions: functions.length,
+    locutusEntries: entries,
+    ignoredFunctions,
+    duplicateEntries: duplicates,
+    allowedExtras: allowedExtras.sort((a, b) => a.name.localeCompare(b.name)),
+    unexpectedExtras,
+    runtimeOnly,
+  }
+}
+
+function formatList(name: string, values: string[], maxItems = 12): string[] {
+  if (!values.length) {
+    return []
+  }
+
+  const lines = [`  ${name}: ${values.length}`]
+  for (const value of values.slice(0, maxItems)) {
+    lines.push(`    - ${value}`)
+  }
+  if (values.length > maxItems) {
+    lines.push(`    - ... (${values.length - maxItems} more)`)
+  }
+  return lines
+}
+
+export function formatRuntimeSurfaceReport(result: RuntimeSurfaceCheckResult): string {
+  const lines = [
+    `${result.language} runtime surface (${result.target})`,
+    `  runtime functions: ${result.runtimeSurface.functions.length}`,
+    `  locutus functions: ${result.locutusFunctions}`,
+    `  comparable entries: ${result.locutusEntries.length}`,
+  ]
+
+  lines.push(
+    ...formatList(
+      'allowed extras',
+      result.allowedExtras.map((extra) => `${extra.name} (${extra.reason})`),
+    ),
+  )
+  lines.push(...formatList('unexpected extras', result.unexpectedExtras))
+  lines.push(...formatList('runtime-only ideas', result.runtimeOnly))
+  lines.push(...formatList('duplicate locutus entries', result.duplicateEntries))
+  lines.push(...formatList('ignored locutus functions', result.ignoredFunctions))
+
+  return lines.join('\n')
+}

--- a/test/parity/lib/types.ts
+++ b/test/parity/lib/types.ts
@@ -51,6 +51,33 @@ export interface DockerConfig {
   mountRepo?: boolean
 }
 
+export interface RuntimeSurfaceSnapshot {
+  language: string
+  target: string
+  functions: string[]
+}
+
+export interface RuntimeSurfaceExtra {
+  name: string
+  reason: string
+}
+
+export interface RuntimeSurfaceLocutusFunction {
+  path: string
+  language: string
+  category: string
+  name: string
+}
+
+export interface RuntimeSurfaceAdapter {
+  /** Discover the callable/runtime function surface from the target runtime. */
+  discover(): Promise<RuntimeSurfaceSnapshot> | RuntimeSurfaceSnapshot
+  /** Map a Locutus function into the comparable runtime surface name, or null to ignore it. */
+  getLocutusEntry(func: RuntimeSurfaceLocutusFunction): string | null
+  /** Intentional Locutus-only entries that should not fail the surface check. */
+  allowedExtras?: ReadonlyMap<string, string>
+}
+
 export interface LanguageHandler {
   /** Translate JS example code to native language code */
   translate(jsCode: string[], funcName: string, category?: string): string
@@ -70,6 +97,8 @@ export interface LanguageHandler {
   dockerCmd(code: string): string[]
   /** Whether to mount the repo in Docker */
   mountRepo?: boolean
+  /** Optional runtime surface discovery for guardrail checks. */
+  runtimeSurface?: RuntimeSurfaceAdapter
 }
 
 export interface VerifyOptions {

--- a/test/util/runtime-surface.vitest.ts
+++ b/test/util/runtime-surface.vitest.ts
@@ -1,0 +1,111 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { findFunctionSources } from '../parity/lib/parser.ts'
+import { compareRuntimeSurface, resolveRuntimeSurfaceLanguages } from '../parity/lib/runtime-surface.ts'
+import type { FunctionInfo, LanguageHandler, RuntimeSurfaceSnapshot } from '../parity/lib/types.ts'
+
+function makeFunction(path: string, name: string): FunctionInfo {
+  return {
+    path,
+    language: 'php',
+    category: 'array',
+    name,
+    examples: [],
+    dependsOn: [],
+    verified: ['PHP 8.3'],
+    isImpossible: false,
+  }
+}
+
+const runtimeSurface: RuntimeSurfaceSnapshot = {
+  language: 'php',
+  target: 'PHP 8.3',
+  functions: ['array_values', 'sort'],
+}
+
+const handler: LanguageHandler = {
+  translate: () => '',
+  normalize: (output) => output,
+  skipList: new Set(),
+  dockerImage: 'php:8.3-cli',
+  displayName: 'PHP',
+  version: '8.3',
+  get parityValue() {
+    return 'PHP 8.3'
+  },
+  dockerCmd: () => ['php', '-r', ''],
+  runtimeSurface: {
+    discover: async () => runtimeSurface,
+    getLocutusEntry: (func) => func.name,
+    allowedExtras: new Map([['money_format', 'removed upstream but intentionally retained']]),
+  },
+}
+
+describe('runtime surface guardrail', () => {
+  it('allows explicitly classified Locutus extras and reports runtime-only ideas', () => {
+    const result = compareRuntimeSurface(
+      [
+        makeFunction('php/array/array_values', 'array_values'),
+        makeFunction('php/strings/money_format', 'money_format'),
+      ],
+      handler,
+      runtimeSurface,
+    )
+
+    expect(result.allowedExtras).toEqual([
+      { name: 'money_format', reason: 'removed upstream but intentionally retained' },
+    ])
+    expect(result.unexpectedExtras).toEqual([])
+    expect(result.runtimeOnly).toEqual(['sort'])
+  })
+
+  it('fails unclassified Locutus extras', () => {
+    const result = compareRuntimeSurface(
+      [
+        makeFunction('php/array/array_values', 'array_values'),
+        makeFunction('php/misc/create_function', 'create_function'),
+      ],
+      handler,
+      runtimeSurface,
+    )
+
+    expect(result.unexpectedExtras).toEqual(['create_function'])
+  })
+
+  it('rejects mistyped or unsupported requested languages instead of silently ignoring them', () => {
+    const resolution = resolveRuntimeSurfaceLanguages(
+      ['php', 'phpp', 'python'],
+      ['php', 'python'],
+      (language) => language === 'php',
+    )
+
+    expect(resolution.selected).toEqual(['php'])
+    expect(resolution.unknown).toEqual(['phpp'])
+    expect(resolution.unavailable).toEqual(['python'])
+  })
+
+  it('includes source functions even when they do not define examples', () => {
+    const root = mkdtempSync(join(tmpdir(), 'locutus-runtime-surface-'))
+    const srcDir = join(root, 'src')
+    const categoryDir = join(srcDir, 'php', 'array')
+
+    mkdirSync(categoryDir, { recursive: true })
+    writeFileSync(
+      join(categoryDir, 'array_values.ts'),
+      'export function array_values(input: unknown) { return input }\n',
+      'utf8',
+    )
+
+    try {
+      const functions = findFunctionSources(srcDir, 'php')
+
+      expect(functions.map((func) => func.path)).toEqual(['php/array/array_values'])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/util/select-parity-targets.vitest.ts
+++ b/test/util/select-parity-targets.vitest.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildReverseDependencies,
   computeParitySelection,
+  computeRuntimeSurfaceLanguages,
   SMOKE_PARITY_TARGETS,
 } from '../../scripts/select-parity-targets.ts'
 import type { FunctionInfo } from '../parity/lib/types.ts'
@@ -122,5 +123,14 @@ describe('select-parity-targets', () => {
     expect(selection.mode).toBe('selective')
     expect(selection.selectedTargets).toEqual([])
     expect(selection.targets).toEqual([...SMOKE_PARITY_TARGETS])
+  })
+
+  it('only requests runtime-surface checks for relevant PR changes', () => {
+    expect(
+      computeRuntimeSurfaceLanguages(['website/source/index.html', 'docs/prompts/selective-parity-ci-plan.md']),
+    ).toEqual([])
+
+    expect(computeRuntimeSurfaceLanguages(['src/php/array/array_flip.ts'])).toEqual(['php'])
+    expect(computeRuntimeSurfaceLanguages(['test/parity/lib/runtime-surface.ts'])).toEqual(['php'])
   })
 })


### PR DESCRIPTION
## Summary
- add a generic parity-adjacent runtime surface checker and wire PHP 8.3 as the first adapter-backed implementation
- compare the shipped PHP source surface against the live `php:8.3-cli` callable surface, with explicit allowlisting for intentional Locutus-only extras
- gate PR runtime-surface checks through the existing selector so docs-only or unrelated PRs do not pay a new Docker cost

## Validation
- corepack yarn exec vitest run test/util/runtime-surface.vitest.ts
- corepack yarn exec vitest run test/util/select-parity-targets.vitest.ts
- corepack yarn test:runtime-surface php
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/nightly-parity.yml')"
- corepack yarn check
- ~/code/dotfiles/bin/council.ts review
