### PR TITLE
test: add runtime surface policy inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Released: TBA. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.14...mai
 ### Infrastructure
 
 - Added a parity-adjacent runtime-surface guardrail that discovers callable functions from the target PHP 8.3 Docker image, compares them against Locutus' shipped PHP surface, hard-fails on unclassified Locutus-only extras, and reports runtime-only functions as inspiration rather than CI failures.
+- Added a shared runtime-surface policy inventory in `docs/runtime-surface-policy.yml` so intentional shipped extras, wanted runtime-only functions, and explicitly out-of-scope runtime functions are tracked separately from the CI hard-fail rules.
 
 ## v3.0.14
 

--- a/docs/prompts/LOG.md
+++ b/docs/prompts/LOG.md
@@ -1826,3 +1826,30 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
 - Key learnings:
   - The live PHP 8.3 container surface is already useful as both a guardrail and an idea backlog: this first pass found 24 intentional Locutus-only extras and 887 runtime-only functions worth treating as inspiration rather than failures.
   - Keeping the classification policy on the language adapter itself makes the system generic enough for other runtimes without locking us into PHP-specific filenames or one-off scripts.
+
+### Iteration 91
+
+2026-03-12
+
+- **Area: Parity infrastructure + Backlog curation**
+- Plan:
+  - Turn the raw runtime-surface output into a living inventory that distinguishes intentional extras from desired future ports and explicit non-goals.
+  - Keep CI fail conditions narrow by continuing to fail only on unclassified shipped extras or mapping/discovery problems.
+  - Move the classification data out of the PHP adapter and into a human-maintained generic policy file.
+- Progress:
+  - Added `docs/runtime-surface-policy.yml` as the first shared inventory for runtime-surface classifications.
+  - Added a generic loader/validator in `test/parity/lib/runtime-surface-policy.ts`.
+  - Moved PHP extra classification out of `test/parity/lib/languages/php.ts` and into the policy file.
+  - Extended the report to distinguish:
+    - classified Locutus extras by status
+    - classified runtime-only backlog entries by status
+    - remaining unclassified runtime-only ideas
+  - Seeded the PHP runtime-only backlog with a first split between:
+    - wanted: `array_is_list`, `array_key_first`, `array_key_last`
+    - out of scope: side-effectful/process/environment helpers like `chdir`, `chmod`, `chroot`, `assert`, and `class_alias`
+- Validation:
+  - `corepack yarn exec vitest run test/util/runtime-surface.vitest.ts`
+  - `corepack yarn test:runtime-surface php`
+- Key learnings:
+  - The inventory becomes much more useful once runtime-only functions are separated into “wanted”, “out_of_scope”, and “still unclassified” instead of appearing as one giant flat count.
+  - Keeping the policy file generic and human-readable makes it viable as a cross-language backlog without weakening the CI guardrail semantics.

--- a/docs/runtime-surface-policy.yml
+++ b/docs/runtime-surface-policy.yml
@@ -1,0 +1,108 @@
+php:
+  locutusExtras:
+    bcadd:
+      status: extension_dependent
+      reason: bcmath is not enabled in the base parity container, but the function remains a useful PHP port.
+    bccomp:
+      status: extension_dependent
+      reason: bcmath is not enabled in the base parity container, but the function remains a useful PHP port.
+    bcdiv:
+      status: extension_dependent
+      reason: bcmath is not enabled in the base parity container, but the function remains a useful PHP port.
+    bcmul:
+      status: extension_dependent
+      reason: bcmath is not enabled in the base parity container, but the function remains a useful PHP port.
+    bcround:
+      status: extension_dependent
+      reason: bcmath is not enabled in the base parity container, but the function remains a useful PHP port.
+    bcscale:
+      status: extension_dependent
+      reason: bcmath is not enabled in the base parity container, but the function remains a useful PHP port.
+    bcsub:
+      status: extension_dependent
+      reason: bcmath is not enabled in the base parity container, but the function remains a useful PHP port.
+    convert_cyr_string:
+      status: legacy_keep
+      reason: Removed upstream in PHP 8.0, but still retained as a legacy compatibility port.
+    each:
+      status: legacy_keep
+      reason: Removed upstream in PHP 8.0, but still retained as a legacy compatibility port.
+    echo:
+      status: language_construct
+      reason: Modeled pragmatically in Locutus even though it is a PHP language construct rather than a callable runtime function.
+    empty:
+      status: language_construct
+      reason: Modeled pragmatically in Locutus even though it is a PHP language construct rather than a callable runtime function.
+    gopher_parsedir:
+      status: keep
+      reason: Niche helper retained as an explicit Locutus port.
+    i18n_loc_get_default:
+      status: extension_dependent
+      reason: Intl helper retained even though it is not exposed by the base parity container.
+    i18n_loc_set_default:
+      status: extension_dependent
+      reason: Intl helper retained even though it is not exposed by the base parity container.
+    is_binary:
+      status: legacy_keep
+      reason: Legacy alias retained for compatibility with older PHP-oriented code.
+    is_buffer:
+      status: legacy_keep
+      reason: Legacy alias retained for compatibility with older PHP-oriented code.
+    is_real:
+      status: legacy_keep
+      reason: Legacy alias retained for compatibility with older PHP-oriented code.
+    is_unicode:
+      status: legacy_keep
+      reason: Legacy alias retained for compatibility with older PHP-oriented code.
+    isset:
+      status: language_construct
+      reason: Modeled pragmatically in Locutus even though it is a PHP language construct rather than a callable runtime function.
+    money_format:
+      status: legacy_keep
+      reason: Removed upstream in PHP 8.0, but still retained as a legacy compatibility port.
+    split:
+      status: legacy_keep
+      reason: Removed upstream in PHP 7.0, but still retained as a legacy compatibility port.
+    sql_regcase:
+      status: legacy_keep
+      reason: Removed upstream in PHP 7.0, but still retained as a legacy compatibility port.
+    xdiff_string_diff:
+      status: extension_dependent
+      reason: xdiff is not enabled in the base parity container, but the function remains a useful PHP port.
+    xdiff_string_patch:
+      status: extension_dependent
+      reason: xdiff is not enabled in the base parity container, but the function remains a useful PHP port.
+  runtimeOnly:
+    array_is_list:
+      status: wanted
+      reason: Modern PHP array helper with clear value and a clean JS runtime contract.
+    array_key_first:
+      status: wanted
+      reason: Frequently useful helper that fits Locutus' plain-object array model well.
+    array_key_last:
+      status: wanted
+      reason: Frequently useful helper that fits Locutus' plain-object array model well.
+    assert:
+      status: out_of_scope
+      reason: Runtime assertion and configuration behavior is not a good portability target for Locutus.
+    chdir:
+      status: out_of_scope
+      reason: Process-wide working-directory side effect is outside the project's plain-value portability focus.
+    checkdnsrr:
+      status: out_of_scope
+      reason: Network/environment-dependent behavior is outside the project's portability focus.
+    chgrp:
+      status: out_of_scope
+      reason: Filesystem ownership side effects are outside the project's portability focus.
+    chmod:
+      status: out_of_scope
+      reason: Filesystem permission side effects are outside the project's portability focus.
+    chown:
+      status: out_of_scope
+      reason: Filesystem ownership side effects are outside the project's portability focus.
+    chroot:
+      status: out_of_scope
+      reason: Process and filesystem sandbox side effects are outside the project's portability focus.
+    class_alias:
+      status: out_of_scope
+      reason: Runtime class table mutation is not a good fit for Locutus' plain-value portability model.

--- a/scripts/check-runtime-surface.ts
+++ b/scripts/check-runtime-surface.ts
@@ -16,10 +16,12 @@ import {
   formatRuntimeSurfaceReport,
   resolveRuntimeSurfaceLanguages,
 } from '../test/parity/lib/runtime-surface.ts'
+import { getLanguageRuntimeSurfacePolicy, loadRuntimeSurfacePolicy } from '../test/parity/lib/runtime-surface-policy.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
 const SRC = join(ROOT, 'src')
+const RUNTIME_SURFACE_POLICY_PATH = join(ROOT, 'docs', 'runtime-surface-policy.yml')
 
 async function main() {
   const filters = process.argv.slice(2)
@@ -46,6 +48,7 @@ async function main() {
   }
 
   const runnableLanguages = resolution.selected
+  const runtimeSurfacePolicy = loadRuntimeSurfacePolicy(RUNTIME_SURFACE_POLICY_PATH)
 
   if (!runnableLanguages.length) {
     const requested = filters.length ? filters.join(', ') : 'all supported languages'
@@ -69,7 +72,12 @@ async function main() {
 
     const functions = findFunctionSources(SRC, language)
     const runtimeSurface = await handler.runtimeSurface.discover()
-    const result = compareRuntimeSurface(functions, handler, runtimeSurface)
+    const result = compareRuntimeSurface(
+      functions,
+      handler,
+      runtimeSurface,
+      getLanguageRuntimeSurfacePolicy(runtimeSurfacePolicy, language),
+    )
 
     console.log(formatRuntimeSurfaceReport(result))
     console.log('')

--- a/scripts/select-parity-targets.ts
+++ b/scripts/select-parity-targets.ts
@@ -39,6 +39,7 @@ const FORCE_FULL_PATHS = new Set([
 
 const FORCE_FULL_PREFIXES = ['.github/workflows/', 'test/parity/lib/']
 const RUNTIME_SURFACE_FORCE_ALL_PATHS = new Set([
+  'docs/runtime-surface-policy.yml',
   'scripts/check-runtime-surface.ts',
   'test/parity/lib/runtime-surface.ts',
   'test/util/runtime-surface.vitest.ts',

--- a/src/_util/vendor.d.ts
+++ b/src/_util/vendor.d.ts
@@ -15,6 +15,7 @@ declare module 'indent-string' {
 declare module 'js-yaml' {
   interface YamlApi {
     dump(value: unknown, options?: unknown): string
+    load(value: string, options?: unknown): unknown
   }
 
   const YAML: YamlApi

--- a/test/parity/lib/languages/php.ts
+++ b/test/parity/lib/languages/php.ts
@@ -33,33 +33,6 @@ export const PHP_SKIP_LIST = new Set([
   'echo',
 ])
 
-const PHP_ALLOWED_RUNTIME_SURFACE_EXTRAS = new Map<string, string>([
-  ['bcadd', 'bcmath extension is not enabled in the base parity container'],
-  ['bccomp', 'bcmath extension is not enabled in the base parity container'],
-  ['bcdiv', 'bcmath extension is not enabled in the base parity container'],
-  ['bcmul', 'bcmath extension is not enabled in the base parity container'],
-  ['bcround', 'bcmath extension is not enabled in the base parity container'],
-  ['bcscale', 'bcmath extension is not enabled in the base parity container'],
-  ['bcsub', 'bcmath extension is not enabled in the base parity container'],
-  ['convert_cyr_string', 'removed in PHP 8.0 but intentionally retained as a legacy port'],
-  ['each', 'removed in PHP 8.0 but intentionally retained as a legacy port'],
-  ['echo', 'PHP language construct, not a callable runtime function'],
-  ['empty', 'PHP language construct, not a callable runtime function'],
-  ['gopher_parsedir', 'niche extension helper retained as an explicit Locutus port'],
-  ['i18n_loc_get_default', 'PECL intl helper retained as an explicit Locutus port'],
-  ['i18n_loc_set_default', 'PECL intl helper retained as an explicit Locutus port'],
-  ['is_binary', 'legacy PHP alias/helper retained as an explicit Locutus port'],
-  ['is_buffer', 'legacy PHP alias/helper retained as an explicit Locutus port'],
-  ['is_real', 'legacy PHP alias/helper retained as an explicit Locutus port'],
-  ['is_unicode', 'legacy PHP alias/helper retained as an explicit Locutus port'],
-  ['isset', 'PHP language construct, not a callable runtime function'],
-  ['money_format', 'removed in PHP 8.0 but intentionally retained as a legacy port'],
-  ['split', 'removed in PHP 7.0 but intentionally retained as a legacy port'],
-  ['sql_regcase', 'removed in PHP 7.0 but intentionally retained as a legacy port'],
-  ['xdiff_string_diff', 'xdiff extension is not enabled in the base parity container'],
-  ['xdiff_string_patch', 'xdiff extension is not enabled in the base parity container'],
-])
-
 function discoverPhpRuntimeSurface() {
   const result = runInDocker(PHP_DOCKER_IMAGE, [
     'php',
@@ -511,6 +484,5 @@ export const phpHandler: LanguageHandler = {
   runtimeSurface: {
     discover: discoverPhpRuntimeSurface,
     getLocutusEntry: (func) => func.name,
-    allowedExtras: PHP_ALLOWED_RUNTIME_SURFACE_EXTRAS,
   },
 }

--- a/test/parity/lib/runtime-surface-policy.ts
+++ b/test/parity/lib/runtime-surface-policy.ts
@@ -1,0 +1,65 @@
+/**
+ * Runtime surface policy loading and validation.
+ *
+ * This is the human-maintained inventory that distinguishes:
+ * - shipped extras we intentionally keep
+ * - runtime-only functions we want later
+ * - runtime-only functions we explicitly do not want
+ */
+
+import { readFileSync } from 'node:fs'
+
+import YAML from 'js-yaml'
+import { z } from 'zod'
+
+import type { RuntimeSurfaceLanguagePolicy, RuntimeSurfacePolicy } from './types.ts'
+
+const runtimeSurfaceLocutusExtraPolicyStatusSchema = z.enum([
+  'extension_dependent',
+  'keep',
+  'language_construct',
+  'legacy_keep',
+  'removed_upstream',
+])
+
+const runtimeSurfaceRuntimeOnlyPolicyStatusSchema = z.enum(['out_of_scope', 'wanted'])
+
+const locutusExtraPolicyEntrySchema = z
+  .object({
+    status: runtimeSurfaceLocutusExtraPolicyStatusSchema,
+    reason: z.string().min(1),
+  })
+  .strict()
+
+const runtimeOnlyPolicyEntrySchema = z
+  .object({
+    status: runtimeSurfaceRuntimeOnlyPolicyStatusSchema,
+    reason: z.string().min(1),
+  })
+  .strict()
+
+function optionalPolicySection<T extends z.ZodType>(schema: T) {
+  return z.preprocess((value) => (value === null ? undefined : value), schema.optional())
+}
+
+const runtimeSurfaceLanguagePolicySchema = z
+  .object({
+    locutusExtras: optionalPolicySection(z.record(z.string(), locutusExtraPolicyEntrySchema)),
+    runtimeOnly: optionalPolicySection(z.record(z.string(), runtimeOnlyPolicyEntrySchema)),
+  })
+  .strict()
+
+const runtimeSurfacePolicySchema = z.record(z.string(), runtimeSurfaceLanguagePolicySchema)
+
+export function loadRuntimeSurfacePolicy(policyPath: string): RuntimeSurfacePolicy {
+  const raw = readFileSync(policyPath, 'utf8')
+  const parsed = YAML.load(raw) ?? {}
+  return runtimeSurfacePolicySchema.parse(parsed)
+}
+
+export function getLanguageRuntimeSurfacePolicy(
+  policy: RuntimeSurfacePolicy,
+  language: string,
+): RuntimeSurfaceLanguagePolicy {
+  return policy[language] ?? {}
+}

--- a/test/parity/lib/runtime-surface.ts
+++ b/test/parity/lib/runtime-surface.ts
@@ -7,11 +7,11 @@
  */
 
 import type {
-  FunctionInfo,
   LanguageHandler,
   RuntimeSurfaceAdapter,
-  RuntimeSurfaceExtra,
+  RuntimeSurfaceLanguagePolicy,
   RuntimeSurfaceLocutusFunction,
+  RuntimeSurfacePolicyEntry,
   RuntimeSurfaceSnapshot,
 } from './types.ts'
 
@@ -23,15 +23,22 @@ export interface RuntimeSurfaceCheckResult {
   locutusEntries: string[]
   ignoredFunctions: string[]
   duplicateEntries: string[]
-  allowedExtras: RuntimeSurfaceExtra[]
+  classifiedExtras: RuntimeSurfacePolicyMatch[]
   unexpectedExtras: string[]
-  runtimeOnly: string[]
+  classifiedRuntimeOnly: RuntimeSurfacePolicyMatch[]
+  unclassifiedRuntimeOnly: string[]
+  staleLocutusExtraPolicy: RuntimeSurfacePolicyMatch[]
+  staleRuntimeOnlyPolicy: RuntimeSurfacePolicyMatch[]
 }
 
 export interface RuntimeSurfaceLanguageResolution {
   selected: string[]
   unknown: string[]
   unavailable: string[]
+}
+
+export interface RuntimeSurfacePolicyMatch extends RuntimeSurfacePolicyEntry {
+  name: string
 }
 
 export function resolveRuntimeSurfaceLanguages(
@@ -109,6 +116,7 @@ export function compareRuntimeSurface(
   functions: RuntimeSurfaceLocutusFunction[],
   handler: LanguageHandler,
   runtimeSurface: RuntimeSurfaceSnapshot,
+  policy: RuntimeSurfaceLanguagePolicy = {},
 ): RuntimeSurfaceCheckResult {
   if (!handler.runtimeSurface) {
     throw new Error(`Language ${handler.displayName} does not define a runtime surface adapter`)
@@ -118,24 +126,53 @@ export function compareRuntimeSurface(
   const runtimeEntries = [...new Set(runtimeSurface.functions)].sort()
   const runtimeSet = new Set(runtimeEntries)
   const locutusSet = new Set(entries)
-  const allowedExtras: RuntimeSurfaceExtra[] = []
+  const classifiedExtras: RuntimeSurfacePolicyMatch[] = []
   const unexpectedExtras: string[] = []
+  const seenLocutusExtraPolicy = new Set<string>()
 
   for (const entry of entries) {
     if (runtimeSet.has(entry)) {
       continue
     }
 
-    const reason = handler.runtimeSurface.allowedExtras?.get(entry)
-    if (reason) {
-      allowedExtras.push({ name: entry, reason })
+    const policyEntry = policy.locutusExtras?.[entry]
+    if (policyEntry) {
+      seenLocutusExtraPolicy.add(entry)
+      classifiedExtras.push({ name: entry, ...policyEntry })
       continue
     }
 
     unexpectedExtras.push(entry)
   }
 
-  const runtimeOnly = runtimeEntries.filter((entry) => !locutusSet.has(entry))
+  const classifiedRuntimeOnly: RuntimeSurfacePolicyMatch[] = []
+  const unclassifiedRuntimeOnly: string[] = []
+  const seenRuntimeOnlyPolicy = new Set<string>()
+
+  for (const entry of runtimeEntries) {
+    if (locutusSet.has(entry)) {
+      continue
+    }
+
+    const policyEntry = policy.runtimeOnly?.[entry]
+    if (policyEntry) {
+      seenRuntimeOnlyPolicy.add(entry)
+      classifiedRuntimeOnly.push({ name: entry, ...policyEntry })
+      continue
+    }
+
+    unclassifiedRuntimeOnly.push(entry)
+  }
+
+  const staleLocutusExtraPolicy = Object.entries(policy.locutusExtras ?? {})
+    .filter(([name]) => !seenLocutusExtraPolicy.has(name))
+    .map(([name, entry]) => ({ name, ...entry }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  const staleRuntimeOnlyPolicy = Object.entries(policy.runtimeOnly ?? {})
+    .filter(([name]) => !seenRuntimeOnlyPolicy.has(name))
+    .map(([name, entry]) => ({ name, ...entry }))
+    .sort((a, b) => a.name.localeCompare(b.name))
 
   return {
     language: runtimeSurface.language,
@@ -148,9 +185,12 @@ export function compareRuntimeSurface(
     locutusEntries: entries,
     ignoredFunctions,
     duplicateEntries: duplicates,
-    allowedExtras: allowedExtras.sort((a, b) => a.name.localeCompare(b.name)),
+    classifiedExtras: classifiedExtras.sort((a, b) => a.name.localeCompare(b.name)),
     unexpectedExtras,
-    runtimeOnly,
+    classifiedRuntimeOnly: classifiedRuntimeOnly.sort((a, b) => a.name.localeCompare(b.name)),
+    unclassifiedRuntimeOnly,
+    staleLocutusExtraPolicy,
+    staleRuntimeOnlyPolicy,
   }
 }
 
@@ -169,6 +209,33 @@ function formatList(name: string, values: string[], maxItems = 12): string[] {
   return lines
 }
 
+function formatPolicyMatches(label: string, matches: RuntimeSurfacePolicyMatch[], maxItems = 12): string[] {
+  if (!matches.length) {
+    return []
+  }
+
+  const grouped = new Map<string, RuntimeSurfacePolicyMatch[]>()
+  for (const match of matches) {
+    const existing = grouped.get(match.status) ?? []
+    existing.push(match)
+    grouped.set(match.status, existing)
+  }
+
+  const lines: string[] = []
+  for (const status of [...grouped.keys()].sort()) {
+    const entries = grouped.get(status)?.sort((left, right) => left.name.localeCompare(right.name)) ?? []
+    lines.push(`  ${label} [${status}]: ${entries.length}`)
+    for (const entry of entries.slice(0, maxItems)) {
+      lines.push(`    - ${entry.name} (${entry.reason})`)
+    }
+    if (entries.length > maxItems) {
+      lines.push(`    - ... (${entries.length - maxItems} more)`)
+    }
+  }
+
+  return lines
+}
+
 export function formatRuntimeSurfaceReport(result: RuntimeSurfaceCheckResult): string {
   const lines = [
     `${result.language} runtime surface (${result.target})`,
@@ -177,14 +244,12 @@ export function formatRuntimeSurfaceReport(result: RuntimeSurfaceCheckResult): s
     `  comparable entries: ${result.locutusEntries.length}`,
   ]
 
-  lines.push(
-    ...formatList(
-      'allowed extras',
-      result.allowedExtras.map((extra) => `${extra.name} (${extra.reason})`),
-    ),
-  )
+  lines.push(...formatPolicyMatches('locutus extras', result.classifiedExtras))
   lines.push(...formatList('unexpected extras', result.unexpectedExtras))
-  lines.push(...formatList('runtime-only ideas', result.runtimeOnly))
+  lines.push(...formatPolicyMatches('runtime-only backlog', result.classifiedRuntimeOnly))
+  lines.push(...formatList('runtime-only ideas', result.unclassifiedRuntimeOnly))
+  lines.push(...formatPolicyMatches('stale locutus-extra policy', result.staleLocutusExtraPolicy))
+  lines.push(...formatPolicyMatches('stale runtime-only policy', result.staleRuntimeOnlyPolicy))
   lines.push(...formatList('duplicate locutus entries', result.duplicateEntries))
   lines.push(...formatList('ignored locutus functions', result.ignoredFunctions))
 

--- a/test/parity/lib/types.ts
+++ b/test/parity/lib/types.ts
@@ -62,6 +62,29 @@ export interface RuntimeSurfaceExtra {
   reason: string
 }
 
+export type RuntimeSurfaceLocutusExtraPolicyStatus =
+  | 'extension_dependent'
+  | 'keep'
+  | 'language_construct'
+  | 'legacy_keep'
+  | 'removed_upstream'
+
+export type RuntimeSurfaceRuntimeOnlyPolicyStatus = 'out_of_scope' | 'wanted'
+
+export type RuntimeSurfacePolicyStatus = RuntimeSurfaceLocutusExtraPolicyStatus | RuntimeSurfaceRuntimeOnlyPolicyStatus
+
+export interface RuntimeSurfacePolicyEntry<Status extends RuntimeSurfacePolicyStatus = RuntimeSurfacePolicyStatus> {
+  status: Status
+  reason: string
+}
+
+export interface RuntimeSurfaceLanguagePolicy {
+  locutusExtras?: Record<string, RuntimeSurfacePolicyEntry<RuntimeSurfaceLocutusExtraPolicyStatus>> | undefined
+  runtimeOnly?: Record<string, RuntimeSurfacePolicyEntry<RuntimeSurfaceRuntimeOnlyPolicyStatus>> | undefined
+}
+
+export type RuntimeSurfacePolicy = Record<string, RuntimeSurfaceLanguagePolicy>
+
 export interface RuntimeSurfaceLocutusFunction {
   path: string
   language: string
@@ -74,8 +97,6 @@ export interface RuntimeSurfaceAdapter {
   discover(): Promise<RuntimeSurfaceSnapshot> | RuntimeSurfaceSnapshot
   /** Map a Locutus function into the comparable runtime surface name, or null to ignore it. */
   getLocutusEntry(func: RuntimeSurfaceLocutusFunction): string | null
-  /** Intentional Locutus-only entries that should not fail the surface check. */
-  allowedExtras?: ReadonlyMap<string, string>
 }
 
 export interface LanguageHandler {

--- a/test/util/runtime-surface.vitest.ts
+++ b/test/util/runtime-surface.vitest.ts
@@ -6,7 +6,13 @@ import { describe, expect, it } from 'vitest'
 
 import { findFunctionSources } from '../parity/lib/parser.ts'
 import { compareRuntimeSurface, resolveRuntimeSurfaceLanguages } from '../parity/lib/runtime-surface.ts'
-import type { FunctionInfo, LanguageHandler, RuntimeSurfaceSnapshot } from '../parity/lib/types.ts'
+import { loadRuntimeSurfacePolicy } from '../parity/lib/runtime-surface-policy.ts'
+import type {
+  FunctionInfo,
+  LanguageHandler,
+  RuntimeSurfaceLanguagePolicy,
+  RuntimeSurfaceSnapshot,
+} from '../parity/lib/types.ts'
 
 function makeFunction(path: string, name: string): FunctionInfo {
   return {
@@ -41,7 +47,21 @@ const handler: LanguageHandler = {
   runtimeSurface: {
     discover: async () => runtimeSurface,
     getLocutusEntry: (func) => func.name,
-    allowedExtras: new Map([['money_format', 'removed upstream but intentionally retained']]),
+  },
+}
+
+const policy: RuntimeSurfaceLanguagePolicy = {
+  locutusExtras: {
+    money_format: {
+      status: 'legacy_keep',
+      reason: 'removed upstream but intentionally retained',
+    },
+  },
+  runtimeOnly: {
+    sort: {
+      status: 'wanted',
+      reason: 'useful array helper',
+    },
   },
 }
 
@@ -54,13 +74,15 @@ describe('runtime surface guardrail', () => {
       ],
       handler,
       runtimeSurface,
+      policy,
     )
 
-    expect(result.allowedExtras).toEqual([
-      { name: 'money_format', reason: 'removed upstream but intentionally retained' },
+    expect(result.classifiedExtras).toEqual([
+      { name: 'money_format', reason: 'removed upstream but intentionally retained', status: 'legacy_keep' },
     ])
     expect(result.unexpectedExtras).toEqual([])
-    expect(result.runtimeOnly).toEqual(['sort'])
+    expect(result.classifiedRuntimeOnly).toEqual([{ name: 'sort', reason: 'useful array helper', status: 'wanted' }])
+    expect(result.unclassifiedRuntimeOnly).toEqual([])
   })
 
   it('fails unclassified Locutus extras', () => {
@@ -71,6 +93,7 @@ describe('runtime surface guardrail', () => {
       ],
       handler,
       runtimeSurface,
+      policy,
     )
 
     expect(result.unexpectedExtras).toEqual(['create_function'])
@@ -107,5 +130,119 @@ describe('runtime surface guardrail', () => {
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
+  })
+
+  it('loads the shared runtime surface policy inventory', () => {
+    const loaded = loadRuntimeSurfacePolicy(join(process.cwd(), 'docs/runtime-surface-policy.yml'))
+
+    expect(loaded.php?.locutusExtras?.money_format?.status).toBe('legacy_keep')
+    expect(loaded.php?.runtimeOnly?.array_is_list?.status).toBe('wanted')
+    expect(loaded.php?.runtimeOnly?.chdir?.status).toBe('out_of_scope')
+  })
+
+  it('rejects unknown keys in policy sections', () => {
+    const root = mkdtempSync(join(tmpdir(), 'locutus-runtime-surface-policy-'))
+    const policyPath = join(root, 'runtime-surface-policy.yml')
+
+    writeFileSync(
+      policyPath,
+      [
+        'php:',
+        '  runtimeOnyl:',
+        '    array_is_list:',
+        '      status: wanted',
+        '      reason: typo should fail',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+
+    try {
+      expect(() => loadRuntimeSurfacePolicy(policyPath)).toThrow(/unrecognized key/i)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects runtime-only statuses under locutusExtras', () => {
+    const root = mkdtempSync(join(tmpdir(), 'locutus-runtime-surface-policy-'))
+    const policyPath = join(root, 'runtime-surface-policy.yml')
+
+    writeFileSync(
+      policyPath,
+      [
+        'php:',
+        '  locutusExtras:',
+        '    money_format:',
+        '      status: wanted',
+        '      reason: wrong section should fail',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+
+    try {
+      expect(() => loadRuntimeSurfacePolicy(policyPath)).toThrow(/invalid/i)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('treats empty policy sections as empty maps instead of failing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'locutus-runtime-surface-policy-'))
+    const policyPath = join(root, 'runtime-surface-policy.yml')
+
+    writeFileSync(policyPath, ['php:', '  locutusExtras:', '  runtimeOnly:', ''].join('\n'), 'utf8')
+
+    try {
+      expect(loadRuntimeSurfacePolicy(policyPath)).toEqual({
+        php: {},
+      })
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('reports stale policy entries that no longer match either surface', () => {
+    const result = compareRuntimeSurface(
+      [
+        makeFunction('php/array/array_values', 'array_values'),
+        makeFunction('php/strings/money_format', 'money_format'),
+      ],
+      handler,
+      runtimeSurface,
+      {
+        locutusExtras: {
+          money_format: {
+            status: 'legacy_keep',
+            reason: 'removed upstream but intentionally retained',
+          },
+          create_function: {
+            status: 'removed_upstream',
+            reason: 'stale extra should be reported',
+          },
+        },
+        runtimeOnly: {
+          sort: {
+            status: 'wanted',
+            reason: 'useful array helper',
+          },
+          array_is_list: {
+            status: 'wanted',
+            reason: 'stale todo should be reported',
+          },
+        },
+      },
+    ) as {
+      staleLocutusExtraPolicy: Array<{ name: string; reason: string; status: string }>
+      staleRuntimeOnlyPolicy: Array<{ name: string; reason: string; status: string }>
+    }
+
+    expect(result.staleLocutusExtraPolicy).toEqual([
+      { name: 'create_function', reason: 'stale extra should be reported', status: 'removed_upstream' },
+    ])
+    expect(result.staleRuntimeOnlyPolicy).toEqual([
+      { name: 'array_is_list', reason: 'stale todo should be reported', status: 'wanted' },
+    ])
   })
 })

--- a/test/util/select-parity-targets.vitest.ts
+++ b/test/util/select-parity-targets.vitest.ts
@@ -132,5 +132,6 @@ describe('select-parity-targets', () => {
 
     expect(computeRuntimeSurfaceLanguages(['src/php/array/array_flip.ts'])).toEqual(['php'])
     expect(computeRuntimeSurfaceLanguages(['test/parity/lib/runtime-surface.ts'])).toEqual(['php'])
+    expect(computeRuntimeSurfaceLanguages(['docs/runtime-surface-policy.yml'])).toEqual(['php'])
   })
 })


### PR DESCRIPTION
## Summary
- add a shared runtime-surface policy inventory for adapter-backed surface checks
- classify current PHP locutus extras and seed a first runtime-only wanted/out-of-scope backlog
- keep CI fail conditions narrow while reporting stale policy entries and forcing policy-only PRs through runtime-surface checks

## Details
- add `docs/runtime-surface-policy.yml` as the human-maintained inventory for shipped extras and runtime-only candidates
- load and validate the policy through a strict schema with section-specific statuses and empty-section handling
- report stale `locutusExtras` and `runtimeOnly` entries so the inventory can stay current over time
- treat `docs/runtime-surface-policy.yml` as a runtime-surface trigger in selective CI

## Validation
- `corepack yarn exec vitest run test/util/runtime-surface.vitest.ts`
- `corepack yarn exec vitest run test/util/select-parity-targets.vitest.ts`
- `corepack yarn test:runtime-surface php`
- `corepack yarn check`
- `~/code/dotfiles/bin/council.ts review`
