### PR TITLE
fix: sort dense JS arrays in php asort helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Released: TBA. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.14...mai
 - Added a parity-adjacent runtime-surface guardrail that discovers callable functions from the target PHP 8.3 Docker image, compares them against Locutus' shipped PHP surface, hard-fails on unclassified Locutus-only extras, and reports runtime-only functions as inspiration rather than CI failures.
 - Added a shared runtime-surface policy inventory in `docs/runtime-surface-policy.yml` so intentional shipped extras, wanted runtime-only functions, and explicitly out-of-scope runtime functions are tracked separately from the CI hard-fail rules.
 
+### Fixes
+
+- Fixed `php/array/asort` and `php/array/arsort` for real JavaScript arrays by degrading preserved-key sorts to reindexed array output where JS cannot represent PHP's numeric-key iteration order, and corrected `arsort(..., 'SORT_NUMERIC')` to actually sort descending.
+
 ## v3.0.14
 
 Released: 2026-03-11. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.13...v3.0.14).

--- a/docs/php-api-signatures.snapshot
+++ b/docs/php-api-signatures.snapshot
@@ -159,8 +159,12 @@ src/php/array/array_walk.ts :: export function array_walk< TValue extends ArrayW
 src/php/array/array_walk_recursive.ts :: export function array_walk_recursive< TValue extends RecursiveWalkInput = RecursiveWalkInput, TUserdata extends RecursiveWalkInput = RecursiveWalkInput, >( array: RecursiveWalkAssoc<TValue>, funcname: ArrayWalkRecursiveCallback<string, TValue, TUserdata>, userdata?: TUserdata, ): boolean
 src/php/array/array_walk_recursive.ts :: export function array_walk_recursive< TValue extends RecursiveWalkInput = RecursiveWalkInput, TUserdata extends RecursiveWalkInput = RecursiveWalkInput, >( array: RecursiveWalkCollection<TValue>, funcname: | ArrayWalkRecursiveCallback<number, TValue, TUserdata> | ArrayWalkRecursiveCallback<string, TValue, TUserdata>, userdata?: TUserdata, ): boolean
 src/php/array/array_walk_recursive.ts :: export function array_walk_recursive< TValue extends RecursiveWalkInput = RecursiveWalkInput, TUserdata extends RecursiveWalkInput = RecursiveWalkInput, >( array: RecursiveWalkList<TValue>, funcname: ArrayWalkRecursiveCallback<number, TValue, TUserdata>, userdata?: TUserdata, ): boolean
+src/php/array/arsort.ts :: export function arsort<T extends SortValue>( inputArr: Record<string, T> | T[], sortFlags?: SortFlag, ): boolean | Record<string, T> | T[]
 src/php/array/arsort.ts :: export function arsort<T extends SortValue>( inputArr: Record<string, T>, sortFlags?: SortFlag, ): boolean | Record<string, T>
+src/php/array/arsort.ts :: export function arsort<T extends SortValue>(inputArr: T[], sortFlags?: SortFlag): boolean | T[]
+src/php/array/asort.ts :: export function asort<T extends SortValue>( inputArr: Record<string, T> | T[], sortFlags?: SortFlag, ): boolean | Record<string, T> | T[]
 src/php/array/asort.ts :: export function asort<T extends SortValue>( inputArr: Record<string, T>, sortFlags?: SortFlag, ): boolean | Record<string, T>
+src/php/array/asort.ts :: export function asort<T extends SortValue>(inputArr: T[], sortFlags?: SortFlag): boolean | T[]
 src/php/array/count.ts :: export function count(mixedVar: Countable | null | undefined, mode: CountMode = 0): number
 src/php/array/count.ts :: export function count(mixedVar: Countable, mode?: CountMode): number
 src/php/array/count.ts :: export function count(mixedVar: null | undefined, mode?: CountMode): 0

--- a/docs/prompts/LOG.md
+++ b/docs/prompts/LOG.md
@@ -1853,3 +1853,25 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
 - Key learnings:
   - The inventory becomes much more useful once runtime-only functions are separated into “wanted”, “out_of_scope”, and “still unclassified” instead of appearing as one giant flat count.
   - Keeping the policy file generic and human-readable makes it viable as a cross-language backlog without weakening the CI guardrail semantics.
+
+### Iteration 92
+
+2026-03-12
+
+- **Area: PHP runtime correctness**
+- Plan:
+  - Triage the actionable parts of issue `#569` instead of treating the whole report as one blob.
+  - Fix the concrete sort-family regression around `asort`/`arsort` on real JavaScript arrays.
+  - Keep the work focused and regression-driven before deciding whether the JSON-error-state issue from the same report deserves its own follow-up branch.
+- Progress:
+  - Reproduced that `asort([4, 1, 2, 3], 'SORT_NUMERIC')` and `arsort([4, 1, 2, 3], 'SORT_NUMERIC')` leave the original JS array unchanged in the default by-reference path.
+  - Confirmed a second sharp bug in the same area: `arsort(..., 'SORT_NUMERIC')` was using an ascending numeric comparator even for object input.
+  - Added focused custom regression coverage for:
+    - array-input reindexing in `asort` and `arsort`
+    - descending numeric semantics in `arsort`
+  - Updated `asort` and `arsort` so real JS arrays degrade to reindexed sorted arrays, since native arrays cannot preserve PHP-style numeric-key iteration order, and fixed `arsort`'s descending numeric comparator.
+- Validation:
+  - `corepack yarn exec vitest run test/custom/sort-regular-number-order.vitest.ts`
+- Key learnings:
+  - For PHP array helpers that preserve key order, native JavaScript arrays are a representational mismatch rather than just another input type; pragmatic degradation beats silently doing nothing.
+  - The omnibus `#569` issue contains at least two separate real bugs, so it should be handled as split follow-up work rather than one all-or-nothing change set.

--- a/src/php/array/arsort.ts
+++ b/src/php/array/arsort.ts
@@ -6,6 +6,20 @@ import { strnatcmp } from '../strings/strnatcmp.ts'
 type SortValue = PhpRuntimeValue
 type SortFlag = 'SORT_REGULAR' | 'SORT_NUMERIC' | 'SORT_STRING' | 'SORT_LOCALE_STRING'
 
+const isDenseArrayList = <T>(value: T[]): boolean => {
+  const keys = Object.keys(value)
+  return keys.length === value.length && keys.every((key, index) => key === String(index))
+}
+
+const setSortableEntry = <T>(target: Record<string, T> | T[], key: string, value: T): void => {
+  Object.defineProperty(target, key, {
+    value,
+    configurable: true,
+    enumerable: true,
+    writable: true,
+  })
+}
+
 const toSortablePrimitive = (value: SortValue): string | number | bigint | boolean => {
   if (
     typeof value === 'string' ||
@@ -19,10 +33,15 @@ const toSortablePrimitive = (value: SortValue): string | number | bigint | boole
   return String(value ?? '')
 }
 
+export function arsort<T extends SortValue>(inputArr: T[], sortFlags?: SortFlag): boolean | T[]
 export function arsort<T extends SortValue>(
   inputArr: Record<string, T>,
   sortFlags?: SortFlag,
-): boolean | Record<string, T> {
+): boolean | Record<string, T>
+export function arsort<T extends SortValue>(
+  inputArr: Record<string, T> | T[],
+  sortFlags?: SortFlag,
+): boolean | Record<string, T> | T[] {
   //  discuss at: https://locutus.io/php/arsort/
   // original by: Brett Zamir (https://brett-zamir.me)
   // improved by: Brett Zamir (https://brett-zamir.me)
@@ -73,12 +92,13 @@ export function arsort<T extends SortValue>(
     case 'SORT_LOCALE_STRING': {
       const locale = runtime.locales[i18lgd()]
       if (locale?.sorting) {
-        sorter = locale.sorting
+        const localeSorter = locale.sorting
+        sorter = (a, b) => localeSorter(b, a)
       }
       break
     }
     case 'SORT_NUMERIC':
-      sorter = (a, b) => Number(a) - Number(b)
+      sorter = (a, b) => Number(b) - Number(a)
       break
     case 'SORT_REGULAR':
       sorter = regularSortDesc
@@ -90,22 +110,33 @@ export function arsort<T extends SortValue>(
 
   const iniVal = String(runtime.ini['locutus.sortByReference']?.local_value ?? '') || 'on'
   const sortByReference = iniVal === 'on'
-  const populateArr: Record<string, T> = {}
+
+  if (Array.isArray(inputArr) && isDenseArrayList(inputArr)) {
+    const sortedValues = [...inputArr].sort(sorter)
+    const target = sortByReference ? inputArr : []
+    if (sortByReference) {
+      target.length = 0
+    }
+    for (const value of sortedValues) {
+      target.push(value)
+    }
+
+    return sortByReference ? true : target
+  }
 
   for (const [key, value] of Object.entries(inputArr)) {
     valArr.push([key, value])
     if (sortByReference) {
-      delete inputArr[key]
+      Reflect.deleteProperty(inputArr, key)
     }
   }
 
   valArr.sort((a, b) => sorter(a[1], b[1]))
 
+  const populateArr: Record<string, T> | T[] = sortByReference ? inputArr : Array.isArray(inputArr) ? [] : {}
+
   for (const [key, value] of valArr) {
-    populateArr[key] = value
-    if (sortByReference) {
-      inputArr[key] = value
-    }
+    setSortableEntry(populateArr, key, value)
   }
 
   return sortByReference || populateArr

--- a/src/php/array/asort.ts
+++ b/src/php/array/asort.ts
@@ -6,6 +6,20 @@ import { strnatcmp } from '../strings/strnatcmp.ts'
 type SortValue = PhpRuntimeValue
 type SortFlag = 'SORT_REGULAR' | 'SORT_NUMERIC' | 'SORT_STRING' | 'SORT_LOCALE_STRING'
 
+const isDenseArrayList = <T>(value: T[]): boolean => {
+  const keys = Object.keys(value)
+  return keys.length === value.length && keys.every((key, index) => key === String(index))
+}
+
+const setSortableEntry = <T>(target: Record<string, T> | T[], key: string, value: T): void => {
+  Object.defineProperty(target, key, {
+    value,
+    configurable: true,
+    enumerable: true,
+    writable: true,
+  })
+}
+
 const toSortablePrimitive = (value: SortValue): string | number | bigint | boolean => {
   if (
     typeof value === 'string' ||
@@ -19,10 +33,15 @@ const toSortablePrimitive = (value: SortValue): string | number | bigint | boole
   return String(value ?? '')
 }
 
+export function asort<T extends SortValue>(inputArr: T[], sortFlags?: SortFlag): boolean | T[]
 export function asort<T extends SortValue>(
   inputArr: Record<string, T>,
   sortFlags?: SortFlag,
-): boolean | Record<string, T> {
+): boolean | Record<string, T>
+export function asort<T extends SortValue>(
+  inputArr: Record<string, T> | T[],
+  sortFlags?: SortFlag,
+): boolean | Record<string, T> | T[] {
   //  discuss at: https://locutus.io/php/asort/
   // original by: Brett Zamir (https://brett-zamir.me)
   // improved by: Brett Zamir (https://brett-zamir.me)
@@ -93,19 +112,33 @@ export function asort<T extends SortValue>(
 
   const iniVal = String(runtime.ini['locutus.sortByReference']?.local_value ?? '') || 'on'
   const sortByReference = iniVal === 'on'
-  const populateArr: Record<string, T> = sortByReference ? inputArr : {}
+
+  if (Array.isArray(inputArr) && isDenseArrayList(inputArr)) {
+    const sortedValues = [...inputArr].sort(sorter)
+    const target = sortByReference ? inputArr : []
+    if (sortByReference) {
+      target.length = 0
+    }
+    for (const value of sortedValues) {
+      target.push(value)
+    }
+
+    return sortByReference ? true : target
+  }
 
   for (const [key, value] of Object.entries(inputArr)) {
     valArr.push([key, value])
     if (sortByReference) {
-      delete inputArr[key]
+      Reflect.deleteProperty(inputArr, key)
     }
   }
 
   valArr.sort((a, b) => sorter(a[1], b[1]))
 
+  const populateArr: Record<string, T> | T[] = sortByReference ? inputArr : Array.isArray(inputArr) ? [] : {}
+
   for (const [key, value] of valArr) {
-    populateArr[key] = value
+    setSortableEntry(populateArr, key, value)
   }
 
   return sortByReference || populateArr

--- a/test/custom/sort-regular-number-order.vitest.ts
+++ b/test/custom/sort-regular-number-order.vitest.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
+import { getPhpRuntimeEntry, setPhpLocaleDefault, setPhpRuntimeEntry } from '../../src/php/_helpers/_phpRuntimeState.ts'
 import { arsort } from '../../src/php/array/arsort.ts'
 import { asort } from '../../src/php/array/asort.ts'
 import { rsort } from '../../src/php/array/rsort.ts'
 import { sort } from '../../src/php/array/sort.ts'
+import { ini_set } from '../../src/php/info/ini_set.ts'
 
 describe('SORT_REGULAR numeric ordering', () => {
   it('keeps numeric comparison semantics for numeric values', () => {
@@ -26,5 +28,104 @@ describe('SORT_REGULAR numeric ordering', () => {
       ['a', 10],
       ['b', 2],
     ])
+  })
+
+  it('reindexes JS arrays for value-sorting helpers when numeric keys cannot preserve PHP order', () => {
+    const asortInput = [4, 1, 2, 3]
+    const arsortInput = [4, 1, 2, 3]
+
+    asort(asortInput, 'SORT_NUMERIC')
+    arsort(arsortInput, 'SORT_NUMERIC')
+
+    expect(asortInput).toEqual([1, 2, 3, 4])
+    expect(arsortInput).toEqual([4, 3, 2, 1])
+  })
+
+  it('handles large array rebuilds without spreading the full array into push()', () => {
+    const input = Array.from({ length: 120_000 }, (_, index) => 120_000 - index)
+
+    expect(() => asort(input, 'SORT_NUMERIC')).not.toThrow()
+    expect(input[0]).toBe(1)
+    expect(input.at(-1)).toBe(120_000)
+  })
+
+  it('keeps descending numeric semantics for arsort', () => {
+    const arsortInput: Record<string, number> = { a: 4, b: 1, c: 2, d: 3 }
+
+    arsort(arsortInput, 'SORT_NUMERIC')
+
+    expect(Object.entries(arsortInput)).toEqual([
+      ['a', 4],
+      ['d', 3],
+      ['c', 2],
+      ['b', 1],
+    ])
+  })
+
+  it('does not collapse sparse or expando array keys into a dense reindexed list', () => {
+    const input: string[] & { foo?: string } = []
+    input[5] = 'b'
+    input.foo = 'a'
+
+    asort(input, 'SORT_STRING')
+
+    expect(input.length).toBe(6)
+    expect(input[5]).toBe('b')
+    expect(input.foo).toBe('a')
+  })
+
+  it('returns array copies for expando arrays when sortByReference is off', () => {
+    const previousSortByReference = ini_set('locutus.sortByReference', 'off')
+    const asortInput: string[] & { foo?: string; bar?: string } = []
+    const arsortInput: string[] & { foo?: string; bar?: string } = []
+
+    asortInput.foo = 'b'
+    asortInput.bar = 'a'
+    arsortInput.foo = 'b'
+    arsortInput.bar = 'a'
+
+    try {
+      const asortResult = asort(asortInput, 'SORT_STRING')
+      const arsortResult = arsort(arsortInput, 'SORT_STRING')
+
+      expect(Array.isArray(asortResult)).toBe(true)
+      expect(asortResult).toMatchObject({ bar: 'a', foo: 'b' })
+      expect(asortResult).toHaveLength(0)
+
+      expect(Array.isArray(arsortResult)).toBe(true)
+      expect(arsortResult).toMatchObject({ foo: 'b', bar: 'a' })
+      expect(arsortResult).toHaveLength(0)
+    } finally {
+      ini_set('locutus.sortByReference', previousSortByReference ?? 'on')
+    }
+  })
+
+  it('reverses locale-aware sorting for arsort SORT_LOCALE_STRING', () => {
+    const input = { a: 'bbb', b: 'c', c: 'aa' }
+    const previousLocales = getPhpRuntimeEntry('locales')
+    const previousLocaleDefault = getPhpRuntimeEntry('locale_default')
+
+    try {
+      setPhpRuntimeEntry('locales', {
+        sort_probe: {
+          sorting: (left, right) => String(left).length - String(right).length,
+        },
+      })
+      setPhpLocaleDefault('sort_probe')
+      arsort(input, 'SORT_LOCALE_STRING')
+
+      expect(Object.entries(input)).toEqual([
+        ['a', 'bbb'],
+        ['c', 'aa'],
+        ['b', 'c'],
+      ])
+    } finally {
+      setPhpRuntimeEntry('locales', previousLocales)
+      if (typeof previousLocaleDefault === 'string') {
+        setPhpLocaleDefault(previousLocaleDefault)
+      } else {
+        setPhpRuntimeEntry('locale_default', undefined)
+      }
+    }
   })
 })

--- a/test/util/type-signatures.vitest.ts
+++ b/test/util/type-signatures.vitest.ts
@@ -34,6 +34,8 @@ import { array_unique } from '../../src/php/array/array_unique.ts'
 import { array_values } from '../../src/php/array/array_values.ts'
 import { array_walk } from '../../src/php/array/array_walk.ts'
 import { array_walk_recursive } from '../../src/php/array/array_walk_recursive.ts'
+import { arsort } from '../../src/php/array/arsort.ts'
+import { asort } from '../../src/php/array/asort.ts'
 import { count } from '../../src/php/array/count.ts'
 import { sizeof } from '../../src/php/array/sizeof.ts'
 import { call_user_func } from '../../src/php/funchand/call_user_func.ts'
@@ -119,6 +121,14 @@ type ArrayRandSecondParam = Parameters<typeof array_rand>[1]
 type _ArrayRandRejectsStringCount = ExpectFalse<IsAssignable<string, ArrayRandSecondParam>>
 type _ArrayRandAcceptsNumericCount = ExpectTrue<IsAssignable<number, ArrayRandSecondParam>>
 const replacedTyped: { [key: string]: number | undefined } = array_replace({ 0: 1, 1: 2 }, { 1: 9, 2: 5 })
+const asortAssocInput = { a: 3, b: 1 }
+const arsortAssocInput = { a: 1, b: 3 }
+const asortArrayInput = [3, 1]
+const arsortArrayInput = [1, 3]
+const asortAssocTyped: boolean | { [key: string]: number } = asort(asortAssocInput, 'SORT_NUMERIC')
+const arsortAssocTyped: boolean | { [key: string]: number } = arsort(arsortAssocInput, 'SORT_NUMERIC')
+const asortArrayTyped: boolean | number[] = asort(asortArrayInput, 'SORT_NUMERIC')
+const arsortArrayTyped: boolean | number[] = arsort(arsortArrayInput, 'SORT_NUMERIC')
 const multisortNames = ['beta', 'alpha']
 const multisortRanks = [2, 1]
 const multisortTyped: boolean = array_multisort(multisortNames, 'SORT_ASC', multisortRanks, 'SORT_ASC')
@@ -209,6 +219,14 @@ describe('public type signatures', () => {
     expect(randTyped).toBe('0')
     expect(randManyTyped === null || Array.isArray(randManyTyped)).toBe(true)
     expect(replacedTyped).toEqual({ 0: 1, 1: 9, 2: 5 })
+    expect(asortAssocTyped).toBe(true)
+    expect(asortAssocInput).toEqual({ b: 1, a: 3 })
+    expect(arsortAssocTyped).toBe(true)
+    expect(arsortAssocInput).toEqual({ b: 3, a: 1 })
+    expect(asortArrayTyped).toBe(true)
+    expect(asortArrayInput).toEqual([1, 3])
+    expect(arsortArrayTyped).toBe(true)
+    expect(arsortArrayInput).toEqual([3, 1])
     expect(multisortTyped).toBe(true)
     expect(multisortNames).toEqual(['alpha', 'beta'])
     expect(multisortRanks).toEqual([1, 2])


### PR DESCRIPTION
## Summary
- fix `php/array/asort` and `php/array/arsort` for dense JS array inputs by degrading preserved-key sorts into reindexed array output
- correct `arsort(..., 'SORT_NUMERIC')` so descending numeric order actually applies on the key-preserving path too
- keep sparse or expando arrays on the non-dense path while preserving array return types when `locutus.sortByReference` is off

## Context
This is a focused partial response to #569. It addresses the real sort-family runtime bug without taking on the separate JSON error-state work from that omnibus report.

## Validation
- `corepack yarn exec vitest run test/custom/sort-regular-number-order.vitest.ts test/generated/php/array/asort.vitest.ts test/generated/php/array/arsort.vitest.ts test/util/type-signatures.vitest.ts`
- `corepack yarn check`
- `~/code/dotfiles/bin/council.ts review` surfaced one real sparse-array contract issue, which was fixed; the final rerun exceeded 30 minutes without returning another result
