### PR TITLE
fix: clear stale php json last_error state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Ideas that will be planned and find their way into a release at one point
 
 Released: TBA. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.15...main).
 
+### Fixes
+
+- Fixed `php/json/json_decode`, `php/json/json_encode`, and `php/json/json_last_error` interaction so successful JSON operations clear prior error state correctly while still preserving `JSON_ERROR_INF_OR_NAN` for primitive, boxed, and `toJSON()`-introduced non-finite numbers.
+
 ## v3.0.15
 
 Released: 2026-03-13. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.14...v3.0.15).

--- a/docs/prompts/LOG.md
+++ b/docs/prompts/LOG.md
@@ -1893,3 +1893,21 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
 - Key learnings:
   - The sort-family fix is release-worthy because it changes shipped runtime behavior for real PHP parity mismatches, not just tests or tooling.
   - Keeping release notes aligned with the exact contents of `main` avoids dropping adjacent infrastructure work that is already merged and validated.
+
+### Iteration 94
+
+2026-03-13
+
+- **Area: PHP runtime correctness**
+- Plan:
+  - Pick up the remaining concrete bug from issue `#569`: stale JSON error state after a successful `json_encode` or `json_decode`.
+  - Keep the branch narrowly scoped to runtime behavior, with fail-first coverage before touching implementation.
+- Progress:
+  - Added focused util coverage proving that `json_last_error()` stayed stuck at `JSON_ERROR_SYNTAX` after a successful `json_decode` following invalid JSON and after a successful `json_encode` following an unsupported input.
+  - Updated `json_decode` to clear `last_error_json` on successful native `JSON.parse` and fallback `eval` decoding.
+  - Updated `json_encode` to clear `last_error_json` on successful native `JSON.stringify` and fallback encoder success.
+- Validation:
+  - `corepack yarn exec vitest run test/util/php-json-last-error.vitest.ts`
+- Key learnings:
+  - Shared PHP runtime flags need explicit success-path resets, not just failure writes, or parity helpers accumulate stale state across calls.
+  - The remaining `#569` work is genuinely separable into small, releasable correctness fixes.

--- a/src/php/json/json_decode.ts
+++ b/src/php/json/json_decode.ts
@@ -29,7 +29,9 @@ export function json_decode<T = JsonValue>(strJson: string): T | null {
     const parse = json.parse
     if (typeof parse === 'function') {
       try {
-        return parse.call(json, strJson)
+        const parsed = parse.call(json, strJson)
+        setPhpRuntimeEntry('last_error_json', 0)
+        return parsed
       } catch (err) {
         if (!(err instanceof SyntaxError)) {
           throw new Error('Unexpected error type in json_decode()')
@@ -94,6 +96,7 @@ export function json_decode<T = JsonValue>(strJson: string): T | null {
     // in parens to eliminate the ambiguity.
     // biome-ignore lint/security/noGlobalEval: needed for PHP port
     const parsed = eval('(' + text + ')')
+    setPhpRuntimeEntry('last_error_json', 0)
     return parsed
   }
 

--- a/src/php/json/json_encode.ts
+++ b/src/php/json/json_encode.ts
@@ -5,9 +5,22 @@ type JsonPrimitive = string | number | boolean | null
 type JsonObject = { [key: string]: JsonValue }
 type JsonValue = JsonPrimitive | JsonValue[] | JsonObject
 type JsonEncodeInput = PhpRuntimeValue
+type JsonEncodingRuntimeValue = JsonEncodeInput | object | undefined
 
-const isJsonObject = (value: PhpRuntimeValue): value is JsonObject =>
-  typeof value === 'object' && value !== null && !Array.isArray(value)
+const isJsonObject = (value: object): value is JsonObject => !Array.isArray(value)
+
+const unwrapBoxedJsonScalar = (value: JsonEncodingRuntimeValue): JsonEncodingRuntimeValue => {
+  if (value instanceof Number) {
+    return Number(value.valueOf())
+  }
+  if (value instanceof String) {
+    return String(value.valueOf())
+  }
+  if (value instanceof Boolean) {
+    return Boolean(value.valueOf())
+  }
+  return value
+}
 
 export function json_encode(mixedVal: JsonEncodeInput): string | null {
   //       discuss at: https://phpjs.org/functions/json_encode/
@@ -34,11 +47,23 @@ export function json_encode(mixedVal: JsonEncodeInput): string | null {
     if (typeof json === 'object' && json !== null) {
       const stringify = json.stringify
       if (typeof stringify === 'function') {
+        let hasNonFiniteNumber = false
+        const replacer = (_key: string, value: JsonEncodingRuntimeValue): JsonEncodingRuntimeValue => {
+          const normalizedValue = unwrapBoxedJsonScalar(value)
+          if (typeof normalizedValue === 'number' && !Number.isFinite(normalizedValue)) {
+            hasNonFiniteNumber = true
+          }
+          return normalizedValue
+        }
         // Errors will not be caught here if our own equivalent to resource
-        retVal = stringify.call(json, mixedVal)
+        retVal = json.stringify(mixedVal, replacer)
+        if (hasNonFiniteNumber) {
+          throw new SyntaxError('json_encode_inf_or_nan')
+        }
         if (retVal === undefined) {
           throw new SyntaxError('json_encode')
         }
+        setPhpRuntimeEntry('last_error_json', 0)
         return retVal
       }
     }
@@ -98,7 +123,7 @@ export function json_encode(mixedVal: JsonEncodeInput): string | null {
       let length = 0
       const mind = gap
       let partial: string[] = []
-      let value = Array.isArray(holder) ? holder[Number(key)] : holder[String(key)]
+      let value: JsonEncodingRuntimeValue = Array.isArray(holder) ? holder[Number(key)] : holder[String(key)]
 
       // If the value has a toJSON method, call it to obtain a replacement value.
       if (typeof value === 'object' && value !== null) {
@@ -106,6 +131,7 @@ export function json_encode(mixedVal: JsonEncodeInput): string | null {
           value = value.toJSON.call(value, key)
         }
       }
+      value = unwrapBoxedJsonScalar(value)
 
       // What happens next depends on the value's type.
       switch (typeof value) {
@@ -113,8 +139,10 @@ export function json_encode(mixedVal: JsonEncodeInput): string | null {
           return quote(value)
 
         case 'number':
-          // JSON numbers must be finite. Encode non-finite numbers as null.
-          return isFinite(value) ? String(value) : 'null'
+          if (!isFinite(value)) {
+            throw new SyntaxError('json_encode_inf_or_nan')
+          }
+          return String(value)
 
         case 'boolean':
           // If the value is a boolean or null, convert it to a string.
@@ -191,6 +219,7 @@ export function json_encode(mixedVal: JsonEncodeInput): string | null {
     if (typeof encoded !== 'string') {
       throw new SyntaxError('json_encode')
     }
+    setPhpRuntimeEntry('last_error_json', 0)
     return encoded
   } catch (err) {
     // @todo: ensure error handling above throws a SyntaxError in all cases where it could
@@ -199,7 +228,7 @@ export function json_encode(mixedVal: JsonEncodeInput): string | null {
       throw new Error('Unexpected error type in json_encode()')
     }
     // usable by json_last_error()
-    setPhpRuntimeEntry('last_error_json', 4)
+    setPhpRuntimeEntry('last_error_json', err.message === 'json_encode_inf_or_nan' ? 7 : 4)
     return null
   }
 }

--- a/src/php/json/json_last_error.ts
+++ b/src/php/json/json_last_error.ts
@@ -16,6 +16,7 @@ export function json_last_error(): number {
   // JSON_ERROR_CTRL_CHAR = 3
   // but JSON functions auto-escape these, so error not possible in JavaScript
   // JSON_ERROR_SYNTAX = 4
+  // JSON_ERROR_INF_OR_NAN = 7
 
   return getPhpRuntimeNumber('last_error_json', 0)
 }

--- a/test/util/php-json-last-error.vitest.ts
+++ b/test/util/php-json-last-error.vitest.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { json_decode } from '../../src/php/json/json_decode.ts'
+import { json_encode } from '../../src/php/json/json_encode.ts'
+import { json_last_error } from '../../src/php/json/json_last_error.ts'
+
+describe('php json last_error state', () => {
+  const jsonEncodeRuntime = json_encode as (value: object) => string | null
+
+  it('clears json_last_error after a successful json_decode following a syntax failure', () => {
+    expect(json_decode('{')).toBeNull()
+    expect(json_last_error()).toBe(4)
+
+    expect(json_decode('[1,2,3]')).toEqual([1, 2, 3])
+    expect(json_last_error()).toBe(0)
+  })
+
+  it('clears json_last_error after a successful json_encode following an encoding failure', () => {
+    expect(json_encode(() => 'nope')).toBeNull()
+    expect(json_last_error()).toBe(4)
+
+    expect(json_encode({ ok: true })).toBe('{"ok":true}')
+    expect(json_last_error()).toBe(0)
+  })
+
+  it('reports JSON_ERROR_INF_OR_NAN for non-finite numbers instead of clearing the prior error state', () => {
+    expect(json_decode('{')).toBeNull()
+    expect(json_last_error()).toBe(4)
+
+    expect(json_encode({ bad: Number.NaN })).toBeNull()
+    expect(json_last_error()).toBe(7)
+  })
+
+  it('allows toJSON to replace raw non-finite fields with a finite payload', () => {
+    const input = {
+      bad: Number.NaN,
+      toJSON: () => ({ ok: 1 }),
+    }
+
+    expect(json_encode(input)).toBe('{"ok":1}')
+    expect(json_last_error()).toBe(0)
+  })
+
+  it('still reports JSON_ERROR_INF_OR_NAN when toJSON returns non-finite numbers', () => {
+    const input = {
+      toJSON: () => ({ bad: Number.POSITIVE_INFINITY }),
+    }
+
+    expect(json_encode(input)).toBeNull()
+    expect(json_last_error()).toBe(7)
+  })
+
+  it('reports JSON_ERROR_INF_OR_NAN for boxed non-finite numbers too', () => {
+    const boxedNaN = Reflect.construct(Number, [Number.NaN])
+
+    expect(jsonEncodeRuntime({ bad: boxedNaN })).toBeNull()
+    expect(json_last_error()).toBe(7)
+  })
+
+  it('keeps the JSON.stringify receiver for native encode path compatibility', () => {
+    const originalStringify = JSON.stringify
+    let receiver: unknown
+
+    JSON.stringify = function (this: typeof JSON, value, replacer, space) {
+      receiver = this
+      return Reflect.apply(originalStringify, this, [value, replacer, space])
+    }
+
+    try {
+      expect(json_encode({ ok: true })).toBe('{"ok":true}')
+      expect(receiver).toBe(JSON)
+    } finally {
+      JSON.stringify = originalStringify
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- clear `last_error_json` on successful `php/json/json_decode` and `php/json/json_encode` calls
- preserve real `JSON_ERROR_INF_OR_NAN` behavior for primitive, boxed, and `toJSON()`-introduced non-finite numbers
- add focused runtime regression coverage for JSON error-state transitions and native `JSON.stringify` receiver compatibility

## Context
This is the remaining concrete bug follow-up from #569 after the sort-family fix in #572 / `v3.0.15`.

## Validation
- `corepack yarn exec vitest run test/util/php-json-last-error.vitest.ts test/generated/php/json/json_encode.vitest.ts test/generated/php/json/json_last_error.vitest.ts`
- `corepack yarn check`
- `~/code/dotfiles/bin/council.ts review`
  - surfaced real issues around non-finite numbers, `toJSON()` behavior, boxed numbers, native receiver preservation, and changelog placement; all were fixed fail-first
  - final rerun continued into the long multi-agent path without returning another concrete finding before PR creation
