### PR TITLE
ci: auto-create github releases from changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,40 @@ jobs:
           corepack yarn test:parity
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          EXPECTED_TAG="v${PACKAGE_VERSION}"
+          if [ "$EXPECTED_TAG" != "${GITHUB_REF_NAME}" ]; then
+            echo "Tag/version mismatch: expected $EXPECTED_TAG from package.json, got ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
           npm install -g npm@^11.5.1
-          cd dist/
-          npm publish --access public --provenance
+
+          SHOULD_CREATE_GITHUB_RELEASE=0
+          NOTES_FILE=
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "GitHub release already exists: ${GITHUB_REF_NAME}"
+          else
+            SHOULD_CREATE_GITHUB_RELEASE=1
+            NOTES_FILE=$(mktemp)
+            node scripts/extract-release-notes.ts --version "${GITHUB_REF_NAME}" > "$NOTES_FILE"
+          fi
+
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            echo "npm package already published: ${PACKAGE_NAME}@${PACKAGE_VERSION}"
+          else
+            cd dist/
+            npm publish --access public --provenance
+            cd ..
+          fi
+
+          if [ "$SHOULD_CREATE_GITHUB_RELEASE" = "1" ]; then
+            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file "$NOTES_FILE"
+          fi
       - name: Website Build
         if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Ideas that will be planned and find their way into a release at one point
 
 Released: TBA. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.16...main).
 
+### CI
+
+- Automated GitHub release-page creation in the tag workflow by extracting notes from the matching `CHANGELOG.md` version section, while keeping reruns idempotent when npm or the GitHub release object already exists.
+
 ## v3.0.16
 
 Released: 2026-03-13. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.15...v3.0.16).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,19 +248,15 @@ Any Core contributor can let our GHA CI create an npm release via OIDC Trusted P
    npm version patch -m "Release v%s" && git push origin main --tags
    ```
 
-3. **Create GitHub Release**: After CI publishes to npm, create a GitHub release with notes from CHANGELOG:
+3. **Let CI publish and create the GitHub Release**:
+   - The tag workflow now publishes to npm and creates the GitHub release page automatically from the matching
+     `## vX.Y.Z` section in `CHANGELOG.md`.
+   - If the release job is rerun after publish, it skips already-published npm versions and already-created GitHub
+     releases cleanly.
+   - Manual fallback, only if the workflow fails after npm publish:
    ```bash
-   # Extract notes for version from CHANGELOG.md, then:
-   gh release create v2.0.35 --title "v2.0.35" --notes "$(cat <<'EOF'
-   ### New Features
-   - Feature description here
-
-   ### Bug Fixes
-   - Fix description here
-
-   Full changelog: https://github.com/locutusjs/locutus/blob/main/CHANGELOG.md
-   EOF
-   )"
+   node scripts/extract-release-notes.ts --version v2.0.35 > /tmp/locutus-release-notes.md
+   gh release create v2.0.35 --title "v2.0.35" --notes-file /tmp/locutus-release-notes.md
    ```
 
 ### Versioning

--- a/docs/prompts/LOG.md
+++ b/docs/prompts/LOG.md
@@ -1928,3 +1928,28 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
 - Key learnings:
   - JSON state bugs are patch-worthy because they change observable runtime behavior across calls, not just edge-case docs or typing.
   - The council-review loop was valuable here because it surfaced multiple concrete parity traps around `NaN`, boxed numbers, and `toJSON()` ordering before the PR landed.
+
+### Iteration 96
+
+2026-03-13
+
+- **Area: Release management**
+- Plan:
+  - Remove the manual GitHub release-page cleanup step that still existed after successful tag publishes.
+  - Keep `CHANGELOG.md` as the single release-notes source of truth instead of introducing a heavier release-management layer.
+- Progress:
+  - Audited GitHub releases and backfilled missing release pages for older tags so the repo now has complete release metadata coverage.
+  - Corrected GitHub's `Latest` release marker after the historical backfill briefly promoted an older release page.
+  - Added a strict release-notes extractor script that reads the exact `## vX.Y.Z` section from `CHANGELOG.md` and hard-fails on missing, duplicated, or empty sections.
+  - Updated the tag workflow to:
+    - verify the pushed tag matches `package.json`
+    - validate release notes before `npm publish` when a GitHub release still needs to be created
+    - skip `npm publish` cleanly when the version already exists
+    - skip changelog parsing entirely on reruns when the GitHub release already exists
+    - create the GitHub release automatically when it does not already exist
+  - Updated maintainer docs so manual `gh release create` is now explicitly the fallback path rather than the normal release flow.
+- Validation:
+  - `corepack yarn exec vitest run test/util/extract-release-notes.vitest.ts`
+- Key learnings:
+  - This repo does not need Changesets for release-page automation; strict changelog extraction is enough as long as CI fails hard on malformed or missing version sections.
+  - Release reruns need idempotency both at npm publish time and at GitHub release creation time, or recovery attempts create misleading noise in Actions history.

--- a/scripts/extract-release-notes.ts
+++ b/scripts/extract-release-notes.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const CHANGELOG_HEADING_PREFIX = '## '
+const THIS_FILE_PATH = fileURLToPath(import.meta.url)
+
+export function extractReleaseNotes(changelog: string, version: string): string {
+  const normalizedChangelog = changelog.replace(/\r\n/g, '\n')
+  const lines = normalizedChangelog.split('\n')
+  const targetHeading = `${CHANGELOG_HEADING_PREFIX}${version}`
+  const matches = lines.reduce<number[]>((indexes, line, index) => {
+    if (line.trim() === targetHeading) {
+      indexes.push(index)
+    }
+    return indexes
+  }, [])
+
+  if (matches.length === 0) {
+    throw new Error(`Release heading not found in CHANGELOG.md: ${targetHeading}`)
+  }
+
+  if (matches.length > 1) {
+    throw new Error(`Release heading appears multiple times in CHANGELOG.md: ${targetHeading}`)
+  }
+
+  const startHeadingIndex = matches.at(0)
+  if (startHeadingIndex === undefined) {
+    throw new Error(`Release heading not found in CHANGELOG.md: ${targetHeading}`)
+  }
+
+  const startIndex = startHeadingIndex + 1
+  let endIndex = lines.length
+
+  for (let index = startIndex; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line !== undefined && line.startsWith(CHANGELOG_HEADING_PREFIX)) {
+      endIndex = index
+      break
+    }
+  }
+
+  const notes = lines.slice(startIndex, endIndex).join('\n').trim()
+
+  if (!notes) {
+    throw new Error(`Release heading has no notes in CHANGELOG.md: ${targetHeading}`)
+  }
+
+  return notes
+}
+
+function parseArgs(args: string[]): { changelogPath: string; version: string } {
+  const parsed = {
+    changelogPath: join(fileURLToPath(new URL('..', import.meta.url)), 'CHANGELOG.md'),
+    version: '',
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--version') {
+      parsed.version = args[index + 1] ?? ''
+      index += 1
+      continue
+    }
+    if (arg === '--changelog') {
+      parsed.changelogPath = args[index + 1] ?? ''
+      index += 1
+      continue
+    }
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  if (!parsed.version) {
+    throw new Error('Missing required --version argument')
+  }
+
+  if (!parsed.changelogPath) {
+    throw new Error('Missing required --changelog argument')
+  }
+
+  return parsed
+}
+
+function main(): void {
+  const { changelogPath, version } = parseArgs(process.argv.slice(2))
+  const changelog = readFileSync(changelogPath, 'utf8')
+  const notes = extractReleaseNotes(changelog, version)
+  process.stdout.write(`${notes}\n`)
+}
+
+if (process.argv[1] === THIS_FILE_PATH) {
+  main()
+}

--- a/test/util/extract-release-notes.vitest.ts
+++ b/test/util/extract-release-notes.vitest.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { extractReleaseNotes } from '../../scripts/extract-release-notes.ts'
+
+describe('extractReleaseNotes', () => {
+  it('returns the body under the requested release heading', () => {
+    const changelog = [
+      '# Changelog',
+      '',
+      '## main',
+      '',
+      'Released: TBA.',
+      '',
+      '## v1.2.3',
+      '',
+      'Released: 2026-03-13.',
+      '',
+      '### Fixes',
+      '',
+      '- Fixed a thing.',
+      '',
+      '## v1.2.2',
+      '',
+      'Released: 2026-03-12.',
+      '',
+    ].join('\n')
+
+    expect(extractReleaseNotes(changelog, 'v1.2.3')).toBe(
+      ['Released: 2026-03-13.', '', '### Fixes', '', '- Fixed a thing.'].join('\n'),
+    )
+  })
+
+  it('throws when the requested release heading is missing', () => {
+    expect(() => extractReleaseNotes('## v1.2.2\n\nReleased: 2026-03-12.\n', 'v1.2.3')).toThrow(/heading not found/i)
+  })
+
+  it('throws when the requested release heading is duplicated', () => {
+    const changelog = ['## v1.2.3', '', 'First body', '', '## v1.2.3', '', 'Second body'].join('\n')
+
+    expect(() => extractReleaseNotes(changelog, 'v1.2.3')).toThrow(/multiple times/i)
+  })
+
+  it('throws when the requested release heading has no notes', () => {
+    const changelog = ['## v1.2.3', '', '## v1.2.2', '', 'Released: 2026-03-12.'].join('\n')
+
+    expect(() => extractReleaseNotes(changelog, 'v1.2.3')).toThrow(/no notes/i)
+  })
+})


### PR DESCRIPTION
## Summary
- add a strict `scripts/extract-release-notes.ts` helper with tests for missing, duplicate, and empty changelog sections
- make tag releases idempotent by validating notes before first publish, skipping changelog parsing when the GitHub release already exists, and creating the release page automatically from `CHANGELOG.md`
- update maintainer docs/logging to reflect that GitHub release creation is now automated with a manual fallback only for recovery

## Validation
- `corepack yarn exec vitest run test/util/extract-release-notes.vitest.ts`
- `corepack yarn check`
- `~/code/dotfiles/bin/council.ts review`
