### PR TITLE
fix: align browser bundling metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ Ideas that will be planned and find their way into a release at one point
 
 Released: TBA. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.17...main).
 
+### Packaging
+
+- Added `crypto: false` to browser-facing package metadata and propagated browser fallbacks into `dist/esm/package.json` so ESM/browser bundlers keep the same builtin-module stubbing as the CommonJS dist package.
+
+### Docs
+
+- Documented that bundle-sensitive browser consumers should prefer per-function deep imports like `locutus/php/strings/sprintf` over category index imports like `locutus/php/strings/index`.
+
 ## v3.0.17
 
 Released: 2026-03-14. [Diff](https://github.com/locutusjs/locutus/compare/v3.0.16...v3.0.17).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,30 @@ console.log(Contains('Locutus', 'cut'))
 // true
 ```
 
+## Bundle Size
+
+For bundle-sensitive browser builds, prefer per-function deep imports over category index imports.
+
+Good:
+
+```typescript
+import { sprintf } from 'locutus/php/strings/sprintf'
+```
+
+Avoid in browser bundles:
+
+```typescript
+import { sprintf } from 'locutus/php/strings/index'
+```
+
+Why:
+
+- deep imports only pull the function you asked for and its real dependencies
+- category index imports can force bundlers to traverse many unrelated exports in the same namespace
+- this matters most in prebundled UMD/browser artifacts where downstream tree-shaking cannot recover later
+
+If you are publishing your own browser bundle on top of Locutus, treat deep imports as the default.
+
 ## Browser Compatibility (Copy-Paste Snippets)
 
 Code shown on function pages (`Module JS` / `Standalone JS`) targets:

--- a/docs/prompts/LOG.md
+++ b/docs/prompts/LOG.md
@@ -2004,3 +2004,21 @@ LLMs log key learnings, progress, and next steps in one `### Iteration ${increme
   - Noted that the separate twig/Locutus bundle-size concern mentioned in the issue comments should be tracked independently if we decide to pursue it.
 - Key learnings:
   - Umbrella issues are fine as initial signal, but once the real fix paths are known they should be closed with shipped-version references instead of left open as mixed-quality backlog.
+
+### Iteration 100
+
+2026-03-14
+
+- **Area: Packaging + docs**
+- Plan:
+  - Follow up on the downstream Twig bundle-size report with Locutus-side fixes we can point to publicly before proposing consumer changes upstream.
+  - Keep the scope on packaging metadata and guidance rather than consumer-specific compatibility shims.
+- Progress:
+  - Added `crypto: false` to root browser metadata so browser bundlers stub the same Node builtin that Twig already has to suppress manually.
+  - Updated `scripts/fix-cjs-exports.ts` so `dist/esm/package.json` now carries the same browser fallback metadata instead of only `{ \"type\": \"module\" }`.
+  - Added a regression assertion in `test/util/fix-cjs-exports.vitest.ts` to keep the root/ESM browser metadata aligned.
+  - Documented bundle-size guidance in `README.md`: per-function deep imports are the recommended path for browser bundles, while category index imports are convenience-oriented and can drag in unrelated exports.
+- Validation:
+  - `corepack yarn exec vitest run test/util/fix-cjs-exports.vitest.ts`
+- Key learnings:
+  - The most important bundle-size win still belongs on the consumer side when they import category indexes, but Locutus should not make browser bundlers rediscover Node builtin fallbacks differently between CommonJS and ESM publication layouts.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "Kevin van Zonneveld <kevin@vanzonneveld.net>",
   "browser": {
     "child_process": false,
+    "crypto": false,
     "fs": false
   },
   "scripts": {

--- a/scripts/fix-cjs-exports.ts
+++ b/scripts/fix-cjs-exports.ts
@@ -11,6 +11,25 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const distDir = process.argv[2] || 'dist'
+
+type PackageJson = {
+  browser?: Record<string, boolean>
+  exports?: Record<string, unknown>
+  main?: string
+  module?: string
+  type?: string
+  types?: string
+}
+
+const readPackageJson = (rootDir: string): PackageJson | undefined => {
+  const packageJsonPath = path.join(rootDir, 'package.json')
+  if (!fs.existsSync(packageJsonPath)) {
+    return undefined
+  }
+
+  return JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as PackageJson
+}
+
 const writeGolangIndexCompatShim = (rootDir: string): void => {
   const cjsStringsDir = path.join(rootDir, 'golang', 'strings')
   const cjsIndex2JsPath = path.join(cjsStringsDir, 'Index2.js')
@@ -48,23 +67,24 @@ const writeEsmPackageJson = (rootDir: string): void => {
   }
 
   const esmPackageJsonPath = path.join(esmDir, 'package.json')
-  const esmPackageJson = { type: 'module' }
+  const rootPackageJson = readPackageJson(rootDir)
+  const esmPackageJson: { type: 'module'; browser?: Record<string, boolean> } = {
+    type: 'module',
+  }
+
+  if (rootPackageJson?.browser) {
+    esmPackageJson.browser = rootPackageJson.browser
+  }
+
   fs.writeFileSync(esmPackageJsonPath, `${JSON.stringify(esmPackageJson, null, 2)}\n`, 'utf-8')
 }
 
 const patchDistPackageJson = (rootDir: string): void => {
-  const packageJsonPath = path.join(rootDir, 'package.json')
-  if (!fs.existsSync(packageJsonPath)) {
+  const packageJson = readPackageJson(rootDir)
+  if (!packageJson) {
     return
   }
-
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as {
-    exports?: Record<string, unknown>
-    type?: string
-    types?: string
-    module?: string
-    main?: string
-  }
+  const packageJsonPath = path.join(rootDir, 'package.json')
 
   packageJson.type = 'commonjs'
   packageJson.main = './index.js'

--- a/test/util/fix-cjs-exports.vitest.ts
+++ b/test/util/fix-cjs-exports.vitest.ts
@@ -25,7 +25,24 @@ describe('fix-cjs-exports script', function () {
       )
       fs.writeFileSync(cjsIndex2DtsPath, 'export declare function Index(): number\n', 'utf-8')
       fs.writeFileSync(esmIndex2JsPath, 'export function Index() { return 1 }\n', 'utf-8')
-      fs.writeFileSync(packageJsonPath, JSON.stringify({ name: 'locutus-dist-test', type: 'module' }, null, 2), 'utf-8')
+      fs.writeFileSync(
+        packageJsonPath,
+        JSON.stringify(
+          {
+            name: 'locutus-dist-test',
+            type: 'module',
+            browser: {
+              child_process: false,
+              crypto: false,
+              fs: false,
+              tls: false,
+            },
+          },
+          null,
+          2,
+        ),
+        'utf-8',
+      )
 
       execFileSync(process.execPath, [path.resolve('scripts/fix-cjs-exports.ts'), tmpDir], { stdio: 'pipe' })
 
@@ -33,11 +50,18 @@ describe('fix-cjs-exports script', function () {
       const esmCompatShimPath = path.join(esmTargetDir, 'Index.js')
       const compatDtsPath = path.join(cjsTargetDir, 'Index.d.ts')
       const esmPackageJsonPath = path.join(tmpDir, 'esm', 'package.json')
-      const updatedPackage = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as { type?: string; main?: string }
+      const updatedPackage = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as {
+        type?: string
+        main?: string
+        browser?: Record<string, boolean>
+      }
       const cjsShim = fs.readFileSync(cjsCompatShimPath, 'utf-8')
       const esmShim = fs.readFileSync(esmCompatShimPath, 'utf-8')
       const shimDts = fs.readFileSync(compatDtsPath, 'utf-8')
-      const esmPackage = JSON.parse(fs.readFileSync(esmPackageJsonPath, 'utf-8')) as { type?: string }
+      const esmPackage = JSON.parse(fs.readFileSync(esmPackageJsonPath, 'utf-8')) as {
+        type?: string
+        browser?: Record<string, boolean>
+      }
 
       expect(cjsShim).toContain("const mod = require('./Index2.js')")
       expect(cjsShim).toContain('exports.Index = mod.Index')
@@ -50,7 +74,14 @@ describe('fix-cjs-exports script', function () {
         module: './esm/index.js',
         types: './index.d.ts',
       })
+      expect(updatedPackage.browser).toEqual({
+        child_process: false,
+        crypto: false,
+        fs: false,
+        tls: false,
+      })
       expect(esmPackage.type).toBe('module')
+      expect(esmPackage.browser).toEqual(updatedPackage.browser)
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- propagate the root `browser` map into `dist/esm/package.json` instead of hardcoding a separate fallback set
- add `crypto: false` to browser-facing package metadata
- document that browser bundles should prefer per-function deep imports over category index imports

## Why
A downstream Twig bundle-size investigation showed that browser consumers can accidentally pull much more of Locutus than intended when they import category indexes. This PR does the two Locutus-side follow-ups worth shipping on our side:

- keep browser builtin-module stubbing aligned between CommonJS and ESM publication layouts
- make the deep-import guidance explicit in the public docs

## Validation
- `corepack yarn exec vitest run test/util/fix-cjs-exports.vitest.ts`
- `corepack yarn lint:ts`
- `~/code/dotfiles/bin/council.ts review`
- `corepack yarn check`

## Downstream note
In a local webpack repro against published `locutus@3.0.17`, the same 9 Twig-used helpers measured roughly:
- `locutus/php/*/index` CommonJS imports: ~156 KB minified
- per-function CommonJS deep imports: ~26 KB minified
- `locutus/php/*/index` ESM imports: ~64 KB minified
- per-function ESM deep imports: ~25 KB minified

So the main bundle-size win still belongs upstream in Twig import selection, but this PR cleans up the Locutus side first.