### PR TITLE
Harden dependency installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install Dependencies
         run: |
-          corepack yarn
+          corepack yarn install --immutable
       - name: Install Browser Runtime
         run: |
           corepack yarn browser:install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,11 @@ jobs:
         run: |
           node scripts/check-engine-bump.ts
       - name: Get yarn cache directory path
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         id: yarn-cache-dir-path
         run: echo "dir=$(corepack yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |

--- a/.github/workflows/nightly-parity.yml
+++ b/.github/workflows/nightly-parity.yml
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install Dependencies
         run: |
-          corepack yarn
+          corepack yarn install --immutable
       - name: Refresh live upstream snapshots
         run: |
           corepack yarn refresh:upstream-surface

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,5 @@ compressionLevel: mixed
 enableGlobalCache: true
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 2880


### PR DESCRIPTION
## Why
Recent npm supply-chain compromises showed that dependency installs and shared CI caches can execute or preserve newly published malicious packages before advisories catch up. This PR reduces that exposure for this repo.

## What changed
- Added Yarn minimal age gate, made CI installs immutable, and prevented tag release builds from restoring shared dependency caches before publishing.

## Validation
- Ran `git diff --check` across the prepared worktree.
- Audited this PR set for `pull_request_target` and release/deploy/CDN cache reuse; patched actionable hits.
- Did not run the full test suite; this is a workflow/config-only change.